### PR TITLE
add create_int_array

### DIFF
--- a/lib/task.ml
+++ b/lib/task.ml
@@ -12,6 +12,9 @@ type pool =
   {domains : unit Domain.t array;
    task_chan : task_msg Chan.t}
 
+let create_int_array : int -> int array = fun n ->
+    Obj.magic (Array.create_float n)
+
 let do_task f p =
   try
     let res = f () in

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -7,6 +7,10 @@ type 'a promise
 type pool
 (** Type of task pool *)
 
+val create_int_array : int -> int array
+(** [create_int_array n] returns an uninitialised array of size n. The
+  * uninitialized array can be further initialised in parallel.*)
+
 val setup_pool : num_domains:int -> pool
 (** Sets up a task execution pool with [num_domains]. *)
 

--- a/test/dune
+++ b/test/dune
@@ -66,3 +66,9 @@
  (libraries domainslib unix)
  (modules prefix_sum)
  (modes native))
+
+(test
+ (name par_init)
+ (libraries domainslib)
+ (modules par_init)
+ (modes native))

--- a/test/par_init.ml
+++ b/test/par_init.ml
@@ -1,0 +1,13 @@
+module T = Domainslib.Task
+
+let num_domains = try int_of_string Sys.argv.(1) with _ -> 4
+let n = try int_of_string Sys.argv.(2) with _ -> 10000
+
+let _ =
+  let arr = T.create_int_array n in
+  let pool = T.setup_pool ~num_domains:(num_domains - 1) in
+  T.parallel_for pool ~chunk_size:(n/num_domains) ~start:0 ~finish:(pred n) ~body:(fun i ->
+    Array.unsafe_set arr i i
+    );
+  Printf.printf "%d\n" (Array.length arr);
+  T.teardown_pool


### PR DESCRIPTION
This patch adds a primitive  `Task.create_int_array n` which returns an uninitialised integer array of length n. 

Stock OCaml and in-effect Multicore OCaml have `Array.create_float` [which](https://github.com/ocaml/ocaml/blob/trunk/stdlib/array.mli#L58) returns a fresh float array. There is no such primitive (yet) for integer arrays. The `Array.init` [primitive](https://github.com/ocaml-multicore/ocaml-multicore/blob/parallel_minor_gc/stdlib/array.ml#L43-L53) walks through the array sequentially to initialise values in the array, which may be a bottleneck in Multicore OCaml programs.

The idea is to use this primitive to allocate an uninitialised array and subsequently do the initialisation in parallel. An easy way to do this is by using the `parallel_for` primitive. One such example is provided in `test/par_init.ml`.