### PR TITLE
Improvement of parallel_for implementation

### DIFF
--- a/lib/task.ml
+++ b/lib/task.ml
@@ -79,7 +79,27 @@ let parallel_for_reduce pool reduce_fun init ~chunk_size ~start ~finish ~body =
   let results = List.map (await pool) ps in
   List.fold_left reduce_fun init results
 
-let parallel_for pool ~chunk_size ~start ~finish ~body =
+let parallel_for pool ?(chunk_size=0) ~start ~finish ~body =
+  let chunk_size = if chunk_size > 0 then chunk_size
+      else begin
+        let n_domains = (Array.length pool.domains) + 1 in
+        let n_tasks = finish - start + 1 in
+        max 1 (n_tasks/(8*n_domains))
+      end
+  in
+  let rec work pool fn s e =
+    if e - s < chunk_size then
+      for i = s to e do fn i done
+    else begin
+      let d = s + ((e - s) / 2) in
+      let left = async pool (fun _ -> work pool fn s d) in
+      work pool fn (d+1) e;
+      await pool left
+    end
+  in
+  work pool body start finish
+
+let parallel_for_sequential pool ~chunk_size ~start ~finish ~body =
   assert (chunk_size > 0);
   let work s e =
     for i=s to e do

--- a/lib/task.ml
+++ b/lib/task.ml
@@ -79,12 +79,13 @@ let parallel_for_reduce pool reduce_fun init ~chunk_size ~start ~finish ~body =
   let results = List.map (await pool) ps in
   List.fold_left reduce_fun init results
 
-let parallel_for pool ?(chunk_size=0) ~start ~finish ~body =
+let parallel_for ?(chunk_size=0) ~start ~finish ~body pool =
   let chunk_size = if chunk_size > 0 then chunk_size
       else begin
         let n_domains = (Array.length pool.domains) + 1 in
         let n_tasks = finish - start + 1 in
-        max 1 (n_tasks/(8*n_domains))
+        if n_domains = 1 then n_tasks
+        else max 1 (n_tasks/(8*n_domains))
       end
   in
   let rec work pool fn s e =

--- a/lib/task.ml
+++ b/lib/task.ml
@@ -99,25 +99,6 @@ let parallel_for pool ?(chunk_size=0) ~start ~finish ~body =
   in
   work pool body start finish
 
-let parallel_for_sequential pool ~chunk_size ~start ~finish ~body =
-  assert (chunk_size > 0);
-  let work s e =
-    for i=s to e do
-      body i
-    done
-  in
-  let rec loop i acc =
-    if i+chunk_size > finish then
-      let p = async pool (fun _ -> work i finish) in
-      p::acc
-    else begin
-      let p = async pool (fun _ -> work i (i+chunk_size-1)) in
-      loop (i+chunk_size) (p::acc)
-    end
-  in
-  let ps = loop start [] in
-  List.iter (await pool) ps
-
 let parallel_scan pool op elements =
 
   let scan_part op elements prefix_sum start finish =

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -27,9 +27,9 @@ val await : pool -> 'a promise -> 'a
  * be returned. If the task had raised an exception, then [await] raises the
  * same exception. *)
 
-val parallel_for: pool -> ?chunk_size:int -> start:int -> finish:int ->
-                   body:(int -> unit) -> unit
-(** [parallel_for p c s f b] behaves similar to [for i=s to f do b i done], but
+val parallel_for: ?chunk_size:int -> start:int -> finish:int ->
+                   body:(int -> unit) -> pool -> unit
+(** [parallel_for c s f b p] behaves similar to [for i=s to f do b i done], but
   * runs the for loop in parallel. The chunk size [c] determines the number of
   * body applications done in one task; this will default to
   * [(finish-start + 1) / (8 * num_domains)]. Individual iterates may be run

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -37,14 +37,6 @@ val parallel_for: pool -> ?chunk_size:int -> start:int -> finish:int ->
   * scheme.
   *)
 
-val parallel_for_sequential: pool -> chunk_size:int -> start:int -> finish:int ->
-                    body:(int -> unit) -> unit
-(** [parallel_for_sequential p c s f b] behaves similar to
-  * [for i=s to f do b i done], bun runs the for loop in parallel.
-  * The chunk size [c] determines the granularity of parallelisation.
-  * Individual iterates may be run in any order. In contrast to
-  * [parallel_for] the caller distributes all tasks to workers. *)
-
 val parallel_for_reduce : pool -> ('a -> 'a -> 'a) -> 'a -> chunk_size:int ->
                           start:int -> finish:int -> body:(int -> 'a) -> 'a
 (** [parallel_for_reduce p r i c s f b] is similar to [parallel_for] except

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -27,12 +27,23 @@ val await : pool -> 'a promise -> 'a
  * be returned. If the task had raised an exception, then [await] raises the
  * same exception. *)
 
-val parallel_for : pool -> chunk_size:int -> start:int -> finish:int ->
+val parallel_for: pool -> ?chunk_size:int -> start:int -> finish:int ->
                    body:(int -> unit) -> unit
 (** [parallel_for p c s f b] behaves similar to [for i=s to f do b i done], but
-  * runs the for loop in parallel. The chunk size [c] determines the
-  * granularity of parallelisation. Individual iterates may be run in any
-  * order. *)
+  * runs the for loop in parallel. The chunk size [c] determines the number of
+  * body applications done in one task; this will default to
+  * [(finish-start + 1) / (8 * num_domains)]. Individual iterates may be run
+  * in any order. Tasks are distributed to workers using a divide-and-conquer
+  * scheme.
+  *)
+
+val parallel_for_sequential: pool -> chunk_size:int -> start:int -> finish:int ->
+                    body:(int -> unit) -> unit
+(** [parallel_for_sequential p c s f b] behaves similar to
+  * [for i=s to f do b i done], bun runs the for loop in parallel.
+  * The chunk size [c] determines the granularity of parallelisation.
+  * Individual iterates may be run in any order. In contrast to
+  * [parallel_for] the caller distributes all tasks to workers. *)
 
 val parallel_for_reduce : pool -> ('a -> 'a -> 'a) -> 'a -> chunk_size:int ->
                           start:int -> finish:int -> body:(int -> 'a) -> 'a

--- a/test/sum_par.ml
+++ b/test/sum_par.ml
@@ -1,14 +1,38 @@
-let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
+let num_domains = try int_of_string Sys.argv.(1) with _ -> 2
 let n = try int_of_string Sys.argv.(2) with _ -> 40
 
 module T = Domainslib.Task
 
 let _ =
+  (* use parallel_for_reduce *)
   let p = T.setup_pool ~num_domains:(num_domains - 1) in
   let sum =
     T.parallel_for_reduce p (+) 0 ~chunk_size:(n/(4*num_domains)) ~start:0
       ~finish:(n-1) ~body:(fun _i -> 1)
   in
   T.teardown_pool p;
-  Printf.printf "Sum is %d\n" sum
+  Printf.printf "Sum is %d\n" sum;
+  assert (sum = n)
+
+let _ =
+  (* explictly use empty pool and default chunk_size *)
+  let p = T.setup_pool ~num_domains:0 in
+  let sum = Atomic.make 0 in
+  T.parallel_for p ~start:0 ~finish:(n-1)
+      ~body:(fun _i -> ignore (Atomic.fetch_and_add sum 1));
+  let sum = Atomic.get sum in
+  T.teardown_pool p;
+  Printf.printf "Sum is %d\n" sum;
+  assert (sum = n)
+
+let _ =
+  (* configured num_domains and default chunk_size *)
+  let p = T.setup_pool ~num_domains:(num_domains - 1) in
+  let sum = Atomic.make 0 in
+  T.parallel_for p ~start:0 ~finish:(n-1)
+      ~body:(fun _i -> ignore (Atomic.fetch_and_add sum 1));
+  let sum = Atomic.get sum in
+  T.teardown_pool p;
+  Printf.printf "Sum is %d\n" sum;
+  assert (sum = n)
 


### PR DESCRIPTION
This PR:
 - introduces a recursive divide-and-conquer scheme for distributing work in `parallel_for`
 - makes the `chunk_size` a parameter that takes a sensible default (`N/(8*num_domains)`)
 - retains the old `parallel_for` as `parallel_for_sequential`

The motivation is to two-fold:
 - improve scaling when we use more than 8-16 cores. 
 - try to provide a roughly sensible default for the `chunk_size` rather than forcing the user to pick a `chunk_size` which can often be poor even for seemingly sensible values.

My design notes for this change are:

Considerations for `parallel_for`
===============================

There are a couple of subtle things that can happen with `parallel_for` concerning: how work is distributed and how a `chunk_size` is chosen.

Work distribution
-----------------

Consider the following work distribution methods:
 - Sequential: the caller creates a single work item for each chunk to be done and distributes each one to the work pool.
 - Divide-and-conquer (DC): if the work is less than chunk_size, do it now without scheduling. If the work is more than chunk_size, split the current work into two, post the first half to the work queue, recursively work on the second half of the work queue.

In the sequential scheme, all the overhead of work queuing, signalling waiting workers and synchronizing on results is taken by the single caller thread. In the DC scheme, while it may generate some extra work items (O(log(n))) the overhead of work queuing, signalling waiting workers and synchronizing on results is now distributed over the workers in the pool.

Benchmarking in Sandmark suggests the DC is noticeably better (often by a significant margin at 16 or more domains).

How to choose chunk_size
------------------------

At first glance, it looks like for balanced workloads you should choose:
  `n_tasks / n_workers`

Firstly experience suggests it is rare for a workload to be truely balanced. Even a basic piece of code with no garbage collection can experience different run times (e.g. different paths through the code, caching or NUMA effects), while in the presence of garbage collection (either minor collection or major slice) different domains can see different execution times for seemingly identical code.

There is a second issue relating to rounding. Consider sequential distribution in the presence of rounding with a chunk_size set to `int(n_tasks / n_workers)`:
   `n_tasks = k * chunk_size + r`
 where
   `k = n_tasks / n_workers`
   `r = n_tasks % n_workers`
There will then be the following chunks to execute:
   `k` chunks of `chunk_size`
   `r / chunk_size` chunks of `chunk_size`
   `1` chunk of `r % chunk_size`
This means that you can end up with an under-utilized pool once the first `k` chunks are finished. Indeed the critical path can often be "time to do `chunk_size` on one worker" greater than the user expected.

It is difficult for users to select a default `chunk_size` that will work well with all permutations of `n_task`, `n_workers`, task variabilities, machine specifics, etc. 

With this in mind, I would like to advocate for a default `chunk_size` of:
  `n_tasks / (8 * n_workers)`
This attempts to exploit any imbalance and reduce the impact of rounding effects. We can't go arbitrarily larger than `8` as there is an overhead in managing the tasks.

(This choice of `8` is also in line with other `parallel_for` implementations out there, in as far as I can tell) 

Benchmarks
-------------
In these sandmark benchmarks, we have the following variants:
 - `dc_parallel_for` when domainslib is using this PR
 - `dflt_chunksz` where I have changed sandmark to use a `chunk_size` of `n_tasks / (8 * n_workers)` when previously it had `n_tasks / n_workers`. 
![dflt_and_dist](https://user-images.githubusercontent.com/1682628/90335363-6dff6d00-dfcc-11ea-8a33-2e7ac4ffedfc.png)
The end-result of using the default `chunk_size` and this PR's implementation of `parallel_for` gives you the blue line. For some benchmarks, the impact can be substantial. Potentially more importantly, with this change, it is less likely for a user to oversize their pool and see a reduction in performance. 

