### PR TITLE
Move to Mutex & Condition from Domain.Sync.{notify/wait}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ run_test:
 	dune exec test/spectralnorm2_multicore.exe 1 2000
 	dune exec test/sum_par.exe 1 100
 	dune exec test/task_exn.exe
+	dune exec test/LU_decomposition_multicore.exe 1 512
 
 clean:
 	dune clean

--- a/lib/chan.ml
+++ b/lib/chan.ml
@@ -91,10 +91,10 @@ let send' {buffer_size; contents} v ~polling =
           let new_contents = Empty {receivers= receivers'} in
           if Atomic.compare_and_set contents old_contents new_contents
           then begin
-            Domain.Mutex.lock mc.mutex;
             r := Some v;
-            Domain.Condition.signal mc.condition;
+            Domain.Mutex.lock mc.mutex;
             Domain.Mutex.unlock mc.mutex;
+            Domain.Condition.signal mc.condition;
             true
            end else loop ()
     end
@@ -200,10 +200,10 @@ let recv' {buffer_size; contents} ~polling =
             in
             if Atomic.compare_and_set contents old_contents new_contents
             then begin
-              Domain.Mutex.lock mc.mutex;
               c := Notified;
-              Domain.Condition.signal mc.condition;
+              Domain.Mutex.lock mc.mutex;
               Domain.Mutex.unlock mc.mutex;
+              Domain.Condition.signal mc.condition;
               Some m
             end else loop ()
         | Some (m, messages'), Some ((ms, sc, mc), senders') ->
@@ -214,10 +214,10 @@ let recv' {buffer_size; contents} ~polling =
             in
             if Atomic.compare_and_set contents old_contents new_contents
             then begin
-              Domain.Mutex.lock mc.mutex;
               sc := Notified;
-              Domain.Condition.signal mc.condition;
+              Domain.Mutex.lock mc.mutex;
               Domain.Mutex.unlock mc.mutex;
+              Domain.Condition.signal mc.condition;
               Some m
             end else loop ()
   in

--- a/lib/chan.ml
+++ b/lib/chan.ml
@@ -1,3 +1,5 @@
+(* mutex_condvar will be used per domain; so multiple fibers or
+   systhreads may share a mutex_condvar variable *)
 type mutex_condvar = {
   mutex: Mutex.t;
   condition: Condition.t
@@ -88,7 +90,7 @@ let send' {buffer_size; contents} v ~polling =
             r := Some v;
             Mutex.lock mc.mutex;
             Mutex.unlock mc.mutex;
-            Condition.signal mc.condition;
+            Condition.broadcast mc.condition;
             true
            end else loop ()
     end
@@ -197,7 +199,7 @@ let recv' {buffer_size; contents} ~polling =
               c := Notified;
               Mutex.lock mc.mutex;
               Mutex.unlock mc.mutex;
-              Condition.signal mc.condition;
+              Condition.broadcast mc.condition;
               Some m
             end else loop ()
         | Some (m, messages'), Some ((ms, sc, mc), senders') ->
@@ -211,7 +213,7 @@ let recv' {buffer_size; contents} ~polling =
               sc := Notified;
               Mutex.lock mc.mutex;
               Mutex.unlock mc.mutex;
-              Condition.signal mc.condition;
+              Condition.broadcast mc.condition;
               Some m
             end else loop ()
   in

--- a/lib/chan.ml
+++ b/lib/chan.ml
@@ -1,38 +1,46 @@
+type mutex_condvar = {
+  mutex: Domain.Mutex.t;
+  condition: Domain.Condition.t
+}
+
+type waiting_notified =
+  | Waiting
+  | Notified
+
 type 'a contents =
-  | Empty of {receivers: ('a option ref * Domain.Condition.t) Fun_queue.t}
-  | NotEmpty of {senders: ('a * Domain.Condition.t) Fun_queue.t; messages: 'a Fun_queue.t}
+  | Empty of {receivers: ('a option ref * mutex_condvar) Fun_queue.t}
+  | NotEmpty of {senders: ('a * waiting_notified ref * mutex_condvar) Fun_queue.t; messages: 'a Fun_queue.t}
 
 type 'a t = {
-  mutex: Domain.Mutex.t;
   buffer_size: int option;
   contents: 'a contents Atomic.t
 }
 
-let condition_key : Domain.Condition.t Domain.DLS.key = Domain.DLS.new_key ()
+let mutex_condvar_key : mutex_condvar Domain.DLS.key = Domain.DLS.new_key ()
 
-let get_condvar m =
-  match Domain.DLS.get condition_key with
+let get_mutex_condvar () =
+  match Domain.DLS.get mutex_condvar_key with
   | None ->
+      let m = Domain.Mutex.create () in
       let c = Domain.Condition.create m in
-      Domain.DLS.set condition_key c;
-      c
-  | Some c -> c
+      let mc = {mutex=m; condition=c} in
+      Domain.DLS.set mutex_condvar_key mc;
+      mc
+  | Some mc -> mc
 
 let make_bounded n =
   if n < 0 then raise (Invalid_argument "Chan.make_bounded") ;
   {buffer_size= Some n;
-   contents = Atomic.make (Empty {receivers= Fun_queue.empty; });
-   mutex = Domain.Mutex.create ();}
+   contents = Atomic.make (Empty {receivers= Fun_queue.empty; })}
 
 let make_unbounded () =
   {buffer_size= None;
-   contents = Atomic.make (Empty {receivers= Fun_queue.empty});
-   mutex = Domain.Mutex.create ();}
+   contents = Atomic.make (Empty {receivers= Fun_queue.empty})}
 
 (* [send'] is shared by both the blocking and polling versions. Returns a
  * boolean indicating whether the send was successful. Hence, it always returns
  * [true] if [polling] is [false]. *)
-let send' {mutex; buffer_size; contents} v ~polling =
+let send' {buffer_size; contents} v ~polling =
   let open Fun_queue in
   let rec loop () =
     let old_contents = Atomic.get contents in
@@ -48,15 +56,21 @@ let send' {mutex; buffer_size; contents} v ~polling =
             begin if not polling then begin
               (* The channel is empty (no senders), no waiting receivers,
                 * buffer size is 0 and we're not polling *)
-              let condition = get_condvar mutex in
+              let mc = get_mutex_condvar () in
+              let cond_slot = ref Waiting in
               let new_contents =
                 NotEmpty
-                  {messages= empty; senders= push empty (v, condition)}
+                  {messages= empty; senders= push empty (v, cond_slot, mc)}
               in
-              Domain.Mutex.lock mutex;
               if Atomic.compare_and_set contents old_contents new_contents
-              then (Domain.Condition.wait condition; true)
-              else (Domain.Mutex.unlock mutex; loop ())
+              then begin
+                Domain.Mutex.lock mc.mutex;
+                while !cond_slot = Waiting do
+                  Domain.Condition.wait mc.condition
+                done;
+                Domain.Mutex.unlock mc.mutex;
+                true
+              end else loop ()
             end else
               (* The channel is empty (no senders), no waiting receivers,
                 * buffer size is 0 and we're polling *)
@@ -71,18 +85,18 @@ let send' {mutex; buffer_size; contents} v ~polling =
             if Atomic.compare_and_set contents old_contents new_contents
             then true
             else loop ()
-      | Some ((r, condition), receivers') ->
+      | Some ((r, mc), receivers') ->
           (* The channel is empty (no senders) and there are waiting receivers
            * *)
           let new_contents = Empty {receivers= receivers'} in
-          Domain.Mutex.lock mutex;
           if Atomic.compare_and_set contents old_contents new_contents
           then begin
+            Domain.Mutex.lock mc.mutex;
             r := Some v;
-            Domain.Condition.signal condition;
-            Domain.Mutex.unlock mutex;
+            Domain.Condition.signal mc.condition;
+            Domain.Mutex.unlock mc.mutex;
             true
-           end else (Domain.Mutex.unlock mutex; loop ())
+           end else loop ()
     end
     | NotEmpty {senders; messages} ->
         (* The channel is not empty *)
@@ -91,19 +105,19 @@ let send' {mutex; buffer_size; contents} v ~polling =
           begin if not polling then
             (* The channel is not empty, the buffer is full and we're not
               * polling *)
-            let condition = get_condvar mutex in
+            let cond_slot = ref Waiting in
+            let mc = get_mutex_condvar () in
             let new_contents =
-              NotEmpty {senders= push senders (v, condition); messages}
+              NotEmpty {senders= push senders (v, cond_slot, mc); messages}
             in
-            Domain.Mutex.lock mutex;
             if Atomic.compare_and_set contents old_contents new_contents then begin
-              Domain.Condition.wait condition;
-              Domain.Mutex.unlock mutex;
+              Domain.Mutex.lock mc.mutex;
+              while !cond_slot = Waiting do
+                Domain.Condition.wait mc.condition;
+              done;
+              Domain.Mutex.unlock mc.mutex;
               true
-            end else begin
-              Domain.Mutex.unlock mutex;
-              loop ()
-            end
+            end else loop ()
           else
             (* The channel is not empty, the buffer is full and we're
               * polling *)
@@ -129,7 +143,7 @@ let send_poll c v = send' c v ~polling:true
 (* [recv'] is shared by both the blocking and polling versions. Returns a an
  * optional value indicating whether the receive was successful. Hence, it
  * always returns [Some v] if [polling] is [false]. *)
-let recv' {mutex; buffer_size; contents} ~polling =
+let recv' {buffer_size; contents} ~polling =
   let open Fun_queue in
   let rec loop () =
     let old_contents = Atomic.get contents in
@@ -139,16 +153,19 @@ let recv' {mutex; buffer_size; contents} ~polling =
         if not polling then begin
           (* The channel is empty (no senders), and we're not polling *)
           let msg_slot = ref None in
-          let condition = get_condvar mutex in
+          let mc = get_mutex_condvar () in
           let new_contents =
-            Empty {receivers= push receivers (msg_slot, condition)}
+            Empty {receivers= push receivers (msg_slot, mc)}
           in
-          Domain.Mutex.lock mutex;
           if Atomic.compare_and_set contents old_contents new_contents then
-            (Domain.Condition.wait condition;
-             Domain.Mutex.unlock mutex;
-             !msg_slot)
-          else (Domain.Mutex.unlock mutex; loop ())
+          begin
+            Domain.Mutex.lock mc.mutex;
+            while !msg_slot = None do
+              Domain.Condition.wait mc.condition;
+            done;
+            Domain.Mutex.unlock mc.mutex;
+            !msg_slot
+          end else loop ()
         end else
           (* The channel is empty (no senders), and we're polling *)
           None
@@ -170,7 +187,7 @@ let recv' {mutex; buffer_size; contents} ~polling =
             if Atomic.compare_and_set contents old_contents new_contents
             then Some m
             else loop ()
-        | None, Some ((m, condition), senders') ->
+        | None, Some ((m, c, mc), senders') ->
             (* The channel is not empty, there are no messages, and there
               * is a waiting sender. This is only possible is the buffer
               * size is 0. *)
@@ -181,26 +198,28 @@ let recv' {mutex; buffer_size; contents} ~polling =
               else
                 NotEmpty {messages; senders= senders'}
             in
-            Domain.Mutex.lock mutex;
             if Atomic.compare_and_set contents old_contents new_contents
             then begin
-              Domain.Condition.signal condition;
-              Domain.Mutex.unlock mutex;
+              Domain.Mutex.lock mc.mutex;
+              c := Notified;
+              Domain.Condition.signal mc.condition;
+              Domain.Mutex.unlock mc.mutex;
               Some m
-            end else (Domain.Mutex.unlock mutex; loop ())
-        | Some (m, messages'), Some ((ms, condition), senders') ->
+            end else loop ()
+        | Some (m, messages'), Some ((ms, sc, mc), senders') ->
             (* The channel is not empty, there is a message, and there is a
               * waiting sender. *)
             let new_contents =
               NotEmpty {messages= push messages' ms; senders= senders'}
             in
-            Domain.Mutex.lock mutex;
             if Atomic.compare_and_set contents old_contents new_contents
             then begin
-              Domain.Condition.signal condition;
-              Domain.Mutex.unlock mutex;
+              Domain.Mutex.lock mc.mutex;
+              sc := Notified;
+              Domain.Condition.signal mc.condition;
+              Domain.Mutex.unlock mc.mutex;
               Some m
-            end else (Domain.Mutex.unlock mutex; loop ())
+            end else loop ()
   in
   loop ()
 

--- a/test/LU_decomposition_multicore.ml
+++ b/test/LU_decomposition_multicore.ml
@@ -1,14 +1,8 @@
 module T = Domainslib.Task
 let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let mat_size = try int_of_string Sys.argv.(2) with _ -> 1200
-let chunk_size = try int_of_string Sys.argv.(3) with _ -> 16
 
-let k : Random.State.t Domain.DLS.key = Domain.DLS.new_key ()
-let get_state () = try Option.get @@ Domain.DLS.get k with _ ->
-  begin
-    Domain.DLS.set k (Random.State.make_self_init ());
-    Option.get @@ Domain.DLS.get k
-  end
+let k = Domain.DLS.new_key (fun () -> Random.State.make_self_init ())
 
 module SquareMatrix = struct
 
@@ -20,9 +14,8 @@ module SquareMatrix = struct
     fa
   let parallel_create pool f : float array =
     let fa = Array.create_float (mat_size * mat_size) in
-    T.parallel_for pool ~chunk_size:(mat_size * mat_size / num_domains) ~start:0
-    ~finish:( mat_size * mat_size - 1) ~body:(fun i ->
-      fa.(i) <- f (i / mat_size) (i mod mat_size));
+    T.parallel_for pool ~start:0 ~finish:( mat_size * mat_size - 1)
+      ~body:(fun i -> fa.(i) <- f (i / mat_size) (i mod mat_size));
     fa
 
   let get (m : float array) r c = m.(r * mat_size + c)
@@ -50,7 +43,7 @@ open SquareMatrix
 let lup pool (a0 : float array) =
   let a = parallel_copy pool a0 in
   for k = 0 to (mat_size - 2) do
-  T.parallel_for pool ~chunk_size:chunk_size ~start:(k + 1) ~finish:(mat_size  -1)
+  T.parallel_for pool ~start:(k + 1) ~finish:(mat_size  -1)
   ~body:(fun row ->
     let factor = get a row k /. get a k k in
     for col = k + 1 to mat_size-1 do
@@ -63,7 +56,7 @@ let lup pool (a0 : float array) =
 let () =
   let pool = T.setup_pool ~num_domains:(num_domains - 1) in
   let a = parallel_create pool
-    (fun _ _ -> (Random.State.float (get_state ()) 100.0) +. 1.0 ) in
+    (fun _ _ -> (Random.State.float (Domain.DLS.get k) 100.0) +. 1.0 ) in
   let lu = lup pool a in
   let _l = parallel_create pool (fun i j -> if i > j then get lu i j else if i = j then 1.0 else 0.0) in
   let _u = parallel_create pool (fun i j -> if i <= j then get lu i j else 0.0) in

--- a/test/LU_decomposition_multicore.ml
+++ b/test/LU_decomposition_multicore.ml
@@ -1,0 +1,70 @@
+module T = Domainslib.Task
+let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
+let mat_size = try int_of_string Sys.argv.(2) with _ -> 1200
+let chunk_size = try int_of_string Sys.argv.(3) with _ -> 16
+
+let k : Random.State.t Domain.DLS.key = Domain.DLS.new_key ()
+let get_state () = try Option.get @@ Domain.DLS.get k with _ ->
+  begin
+    Domain.DLS.set k (Random.State.make_self_init ());
+    Option.get @@ Domain.DLS.get k
+  end
+
+module SquareMatrix = struct
+
+  let create f : float array =
+    let fa = Array.create_float (mat_size * mat_size) in
+    for i = 0 to mat_size * mat_size - 1 do
+      fa.(i) <- f (i / mat_size) (i mod mat_size)
+    done;
+    fa
+  let parallel_create pool f : float array =
+    let fa = Array.create_float (mat_size * mat_size) in
+    T.parallel_for pool ~chunk_size:(mat_size * mat_size / num_domains) ~start:0
+    ~finish:( mat_size * mat_size - 1) ~body:(fun i ->
+      fa.(i) <- f (i / mat_size) (i mod mat_size));
+    fa
+
+  let get (m : float array) r c = m.(r * mat_size + c)
+  let set (m : float array) r c v = m.(r * mat_size + c) <- v
+  let parallel_copy pool a =
+    let n = Array.length a in
+    let copy_part a b i =
+      let s = (i * n / num_domains) in
+      let e = (i+1) * n / num_domains - 1 in
+      Array.blit a s b s (e - s + 1) in
+    let b = Array.create_float n in
+    let rec aux acc num_domains i =
+      if (i = num_domains) then
+        (List.iter (fun e -> T.await pool e) acc)
+      else begin
+        aux ((T.async pool (fun _ -> copy_part a b i))::acc) num_domains (i+1)
+      end
+    in
+    aux [] num_domains 0;
+    b
+end
+
+open SquareMatrix
+
+let lup pool (a0 : float array) =
+  let a = parallel_copy pool a0 in
+  for k = 0 to (mat_size - 2) do
+  T.parallel_for pool ~chunk_size:chunk_size ~start:(k + 1) ~finish:(mat_size  -1)
+  ~body:(fun row ->
+    let factor = get a row k /. get a k k in
+    for col = k + 1 to mat_size-1 do
+      set a row col (get a row col -. factor *. (get a k col))
+      done;
+    set a row k factor )
+  done ;
+  a
+
+let () =
+  let pool = T.setup_pool ~num_domains:(num_domains - 1) in
+  let a = parallel_create pool
+    (fun _ _ -> (Random.State.float (get_state ()) 100.0) +. 1.0 ) in
+  let lu = lup pool a in
+  let _l = parallel_create pool (fun i j -> if i > j then get lu i j else if i = j then 1.0 else 0.0) in
+  let _u = parallel_create pool (fun i j -> if i <= j then get lu i j else 0.0) in
+  T.teardown_pool pool

--- a/test/LU_decomposition_multicore.ml
+++ b/test/LU_decomposition_multicore.ml
@@ -2,7 +2,7 @@ module T = Domainslib.Task
 let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let mat_size = try int_of_string Sys.argv.(2) with _ -> 1200
 
-let k = Domain.DLS.new_key (fun () -> Random.State.make_self_init ())
+let k = Domain.DLS.new_key Random.State.make_self_init
 
 module SquareMatrix = struct
 

--- a/test/dune
+++ b/test/dune
@@ -33,6 +33,14 @@
  (modes native))
 
 (test
+ (name LU_decomposition_multicore)
+ (libraries domainslib)
+ (flags (:standard -runtime-variant d))
+ (modules LU_decomposition_multicore)
+ (modes native))
+
+
+(test
  (name spectralnorm2)
  (modules spectralnorm2)
  (modes native))


### PR DESCRIPTION
This PR is an update of #17. It uses the `Mutex` and `Condition` module as introduced by [ocaml-multicore#548](https://github.com/ocaml-multicore/ocaml-multicore/pull/548).

I got the following sandmark results (detuned machine but using `chrt -1` and `taskset`) for speedup:
![20210429_1545_bremusa_mutex_condvar](https://user-images.githubusercontent.com/1682628/116572075-8d90b880-a903-11eb-91a7-8fff47294771.png)

and execution time:
![20210429_1545_bremusa_mutex_condvar_time](https://user-images.githubusercontent.com/1682628/116670735-00e40a00-a998-11eb-9b8a-d31d40c7ac12.png)
