### PR TITLE
Minor edit to parallel_for docs

### DIFF
--- a/lib/task.mli
+++ b/lib/task.mli
@@ -32,9 +32,9 @@ val parallel_for : ?chunk_size:int -> start:int -> finish:int ->
 (** [parallel_for c s f b p] behaves similar to [for i=s to f do b i done], but
   * runs the for loop in parallel. The chunk size [c] determines the number of
   * body applications done in one task; this will default to
-  * [(finish-start + 1) / (8 * num_domains)]. Individual iterates may be run
-  * in any order. Tasks are distributed to workers using a divide-and-conquer
-  * scheme.
+  * [max(1, (finish-start + 1) / (8 * num_domains))]. Individual iterates may
+  * be run in any order. Tasks are distributed to workers using a
+  * divide-and-conquer scheme.
   *)
 
 val parallel_for_reduce : ?chunk_size:int -> start:int -> finish:int ->


### PR DESCRIPTION
This PR clears up some confusion on the `parallel_for` docs surrounding `chunk_size` default setting. 