### PR TITLE
Task stealing with CL deques

### DIFF
--- a/lib/multi_channel.ml
+++ b/lib/multi_channel.ml
@@ -1,0 +1,113 @@
+
+
+type mutex_condvar = {
+  mutex: Mutex.t;
+  condition: Condition.t
+}
+
+let mc_key =
+  Domain.DLS.new_key (fun () ->
+    let m = Mutex.create () in
+    let c = Condition.create () in
+    {mutex=m; condition=c})
+
+type waiting_released =
+  | Waiting
+  | Released
+
+type 'a t = {
+  mask: int;
+  channels: 'a Chan.t array;
+  waiters: (waiting_released ref * mutex_condvar ) Chan.t;
+}
+
+let rec log2 n =
+  if n <= 1 then 0 else 1 + (log2 (n asr 1))
+
+let make n =
+  let sz = Int.shift_left 1 ((log2 n)+1) in
+  assert ((sz > n) && (sz > 0));
+  assert (Int.logand sz (sz -1) == 0);
+  { mask = sz - 1;
+    channels = Array.init sz (fun _ -> Chan.make_unbounded ());
+    waiters = Chan.make_unbounded ()
+    }
+
+let rec check_waiters mchan =
+  match Chan.recv_poll mchan.waiters with
+    | None -> ()
+    | Some (status, mc) ->
+      begin
+        Mutex.lock mc.mutex;
+        match !status with
+        | Waiting ->
+          begin
+            status := Released;
+            Mutex.unlock mc.mutex;
+            Condition.broadcast mc.condition
+          end
+        | Released ->
+          begin
+            (* this waiter is already released, it might have found something on a poll *)
+            Mutex.unlock mc.mutex;
+            check_waiters mchan
+          end
+      end
+
+let send mchan v =
+  let id = (Domain.self () :> int) in
+  let res = Chan.send mchan.channels.(Int.logand id mchan.mask) v in
+  check_waiters mchan;
+  res
+
+let rec recv_poll_loop mchan cur left =
+  if left = 0 then None
+  else begin
+    match Chan.recv_poll mchan.channels.(Int.logand cur mchan.mask) with
+      | Some _ as v -> v
+      | None -> recv_poll_loop mchan (cur+1) (left-1)
+  end
+
+let recv_poll mchan =
+  recv_poll_loop mchan (Domain.self () :> int) (Array.length mchan.channels)
+
+let rec recv mchan =
+  match recv_poll mchan with
+    | Some v -> v
+    | None ->
+      begin
+        (* Didn't find anything, prepare to block:
+         *  - enqueue our wait block in the waiter queue
+         *  - check the queue again
+         *  - go to sleep if our wait block has not been notified
+         *  - when notified retry the recieve
+         *)
+        let status = ref Waiting in
+        let mc = Domain.DLS.get mc_key in
+        Chan.send mchan.waiters (status, mc);
+        match recv_poll mchan with
+          | Some v ->
+            begin
+              (* need to check the status as might take an item
+                which is not the one an existing sender has woken us
+                to take *)
+              Mutex.lock mc.mutex;
+              begin match !status with
+              | Waiting -> (status := Released; Mutex.unlock mc.mutex)
+              | Released ->
+                (* we were simultaneously released from a sender;
+                  so need to release a waiter *)
+                (Mutex.unlock mc.mutex; check_waiters mchan)
+              end;
+              v
+            end
+          | None ->
+            if !status = Waiting then begin
+               Mutex.lock mc.mutex;
+               while !status = Waiting do
+                 Condition.wait mc.condition mc.mutex
+               done;
+               Mutex.unlock mc.mutex
+            end;
+            recv mchan
+      end

--- a/lib/multi_channel.ml
+++ b/lib/multi_channel.ml
@@ -1,15 +1,24 @@
 
+module Ws_deque = Ws_deque.M
 
 type mutex_condvar = {
   mutex: Mutex.t;
   condition: Condition.t
 }
 
-let mc_key =
+type dls_state = {
+  mc: mutex_condvar;
+  mutable id: int;
+}
+
+let dls_key =
   Domain.DLS.new_key (fun () ->
     let m = Mutex.create () in
     let c = Condition.create () in
-    {mutex=m; condition=c})
+    {
+      mc = {mutex=m; condition=c};
+      id = -1
+    })
 
 type waiting_released =
   | Waiting
@@ -17,20 +26,22 @@ type waiting_released =
 
 type 'a t = {
   mask: int;
-  channels: 'a Chan.t array;
+  channels: 'a Ws_deque.t array;
   waiters: (waiting_released ref * mutex_condvar ) Chan.t;
+  next_domain_id: int Atomic.t;
 }
 
 let rec log2 n =
   if n <= 1 then 0 else 1 + (log2 (n asr 1))
 
 let make n =
-  let sz = Int.shift_left 1 ((log2 n)+1) in
-  assert ((sz > n) && (sz > 0));
-  assert (Int.logand sz (sz -1) == 0);
+  let sz = Int.shift_left 1 (log2 n) in
+  assert ((sz >= n) && (sz > 0));
+  assert (Int.logand sz (sz-1) == 0);
   { mask = sz - 1;
-    channels = Array.init sz (fun _ -> Chan.make_unbounded ());
-    waiters = Chan.make_unbounded ()
+    channels = Array.init sz (fun _ -> Ws_deque.create ());
+    waiters = Chan.make_unbounded ();
+    next_domain_id = Atomic.make 0
     }
 
 let rec check_waiters mchan =
@@ -54,22 +65,43 @@ let rec check_waiters mchan =
           end
       end
 
+let register_domain mchan =
+  let id = Atomic.fetch_and_add mchan.next_domain_id 1 in
+  assert(id < Array.length mchan.channels);
+  id
+
+let get_id_key mchan =
+  let dls_state = Domain.DLS.get dls_key in
+  if dls_state.id >= 0 then dls_state.id
+  else begin
+    let id = (register_domain mchan) in
+    dls_state.id <- id;
+    dls_state.id
+  end
+
+let clear_id_key () =
+  (Domain.DLS.get dls_key).id <- (-1)
+
 let send mchan v =
-  let id = (Domain.self () :> int) in
-  let res = Chan.send mchan.channels.(Int.logand id mchan.mask) v in
+  let id = (get_id_key mchan) in
+  let res = Ws_deque.push mchan.channels.(id) v in
   check_waiters mchan;
   res
 
 let rec recv_poll_loop mchan cur left =
   if left = 0 then None
   else begin
-    match Chan.recv_poll mchan.channels.(Int.logand cur mchan.mask) with
+    match Ws_deque.steal mchan.channels.(Int.logand cur mchan.mask) with
       | Some _ as v -> v
       | None -> recv_poll_loop mchan (cur+1) (left-1)
   end
 
 let recv_poll mchan =
-  recv_poll_loop mchan (Domain.self () :> int) (Array.length mchan.channels)
+  let id = (get_id_key mchan) in
+  match Ws_deque.pop mchan.channels.(id) with
+    | Some _ as v -> v
+    | None ->
+      recv_poll_loop mchan (id + 1) ((Array.length mchan.channels) - 1)
 
 let rec recv mchan =
   match recv_poll mchan with
@@ -83,7 +115,7 @@ let rec recv mchan =
          *  - when notified retry the recieve
          *)
         let status = ref Waiting in
-        let mc = Domain.DLS.get mc_key in
+        let mc = (Domain.DLS.get dls_key).mc in
         Chan.send mchan.waiters (status, mc);
         match recv_poll mchan with
           | Some v ->

--- a/lib/multi_channel.ml
+++ b/lib/multi_channel.ml
@@ -1,3 +1,18 @@
+(*
+ * Copyright (c) 2021, Tom Kelly <ctk21@cl.cam.ac.uk>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
 
 module Ws_deque = Ws_deque.M
 

--- a/lib/task.ml
+++ b/lib/task.ml
@@ -10,7 +10,7 @@ type task_msg =
 
 type pool =
   {domains : unit Domain.t array;
-   task_chan : task_msg Chan.t}
+   task_chan : task_msg Multi_channel.t}
 
 let do_task f p =
   try
@@ -23,9 +23,9 @@ let do_task f p =
     | _ -> ()
 
 let setup_pool ~num_domains =
-  let task_chan = Chan.make_unbounded () in
+  let task_chan = Multi_channel.make (num_domains+1) in
   let rec worker () =
-    match Chan.recv task_chan with
+    match Multi_channel.recv task_chan with
     | Quit -> ()
     | Task (t, p) ->
         do_task t p;
@@ -36,13 +36,13 @@ let setup_pool ~num_domains =
 
 let async pool task =
   let p = Atomic.make None in
-  Chan.send pool.task_chan (Task(task,p));
+  Multi_channel.send pool.task_chan (Task(task,p));
   p
 
 let rec await pool promise =
   match Atomic.get promise with
   | None ->
-      begin match Chan.recv_poll pool.task_chan with
+      begin match Multi_channel.recv_poll pool.task_chan with
       | None -> Domain.Sync.cpu_relax ()
       | Some (Task (t, p)) -> do_task t p
       | Some Quit -> raise TasksActive
@@ -53,7 +53,7 @@ let rec await pool promise =
 
 let teardown_pool pool =
   for _i=1 to Array.length pool.domains do
-    Chan.send pool.task_chan Quit
+    Multi_channel.send pool.task_chan Quit
   done;
   Array.iter Domain.join pool.domains
 

--- a/lib/task.ml
+++ b/lib/task.ml
@@ -26,7 +26,7 @@ let setup_pool ~num_domains =
   let task_chan = Multi_channel.make (num_domains+1) in
   let rec worker () =
     match Multi_channel.recv task_chan with
-    | Quit -> Multi_channel.clear_id_key ();
+    | Quit -> Multi_channel.clear_local_state ();
     | Task (t, p) ->
         do_task t p;
         worker ()
@@ -55,7 +55,7 @@ let teardown_pool pool =
   for _i=1 to Array.length pool.domains do
     Multi_channel.send pool.task_chan Quit
   done;
-  Multi_channel.clear_id_key ();
+  Multi_channel.clear_local_state ();
   Array.iter Domain.join pool.domains
 
 let parallel_for_reduce ?(chunk_size=0) ~start ~finish ~body pool reduce_fun init =

--- a/lib/task.ml
+++ b/lib/task.ml
@@ -26,7 +26,7 @@ let setup_pool ~num_domains =
   let task_chan = Multi_channel.make (num_domains+1) in
   let rec worker () =
     match Multi_channel.recv task_chan with
-    | Quit -> ()
+    | Quit -> Multi_channel.clear_id_key ();
     | Task (t, p) ->
         do_task t p;
         worker ()
@@ -55,6 +55,7 @@ let teardown_pool pool =
   for _i=1 to Array.length pool.domains do
     Multi_channel.send pool.task_chan Quit
   done;
+  Multi_channel.clear_id_key ();
   Array.iter Domain.join pool.domains
 
 let parallel_for_reduce ?(chunk_size=0) ~start ~finish ~body pool reduce_fun init =

--- a/lib/ws_deque.ml
+++ b/lib/ws_deque.ml
@@ -40,7 +40,7 @@ end
 module CArray = struct
 
   type 'a t = {
-    arr  : 'a Atomic.t array;
+    arr  : 'a array;
     mask : int
     }
 
@@ -52,17 +52,17 @@ module CArray = struct
     assert ((sz >= n) && (sz > 0));
     assert (Int.logand sz (sz-1) == 0);
     {
-      arr  = Array.init sz (fun _ -> Atomic.make v);
+      arr  = Array.init sz (fun _ -> v);
       mask = sz - 1
     }
 
   let size t = Array.length t.arr [@@inline]
 
   let get t i =
-    Atomic.get (Array.unsafe_get t.arr (Int.logand i t.mask)) [@@inline]
+    Array.unsafe_get t.arr (Int.logand i t.mask) [@@inline]
 
   let put t i v =
-    Atomic.set (Array.unsafe_get t.arr (Int.logand i t.mask)) v [@@inline]
+    Array.unsafe_set t.arr (Int.logand i t.mask) v [@@inline]
 
   let grow t top bottom =
     let s = size t in
@@ -96,10 +96,10 @@ module M : S = struct
   }
 
   let create () = {
-    top = Atomic.make 0;
-    bottom = Atomic.make 0;
+    top = Atomic.make 1;
+    bottom = Atomic.make 1;
     tab = Atomic.make (CArray.create min_size (Obj.magic ()));
-    next_shrink = min_size / shrink_const
+    next_shrink = 0
   }
 
   let set_next_shrink q =

--- a/lib/ws_deque.ml
+++ b/lib/ws_deque.ml
@@ -170,11 +170,11 @@ module M : S = struct
   let rec steal q =
     let t = Atomic.get q.top in
     let b = Atomic.get q.bottom in
-    let a = Atomic.get q.tab in
     let size = b - t in
     if size <= 0 then
       None
     else
+      let a = Atomic.get q.tab in
       let out = CArray.get a t in
       if Atomic.compare_and_set q.top t (t + 1) then
         Some out

--- a/lib/ws_deque.ml
+++ b/lib/ws_deque.ml
@@ -52,7 +52,7 @@ module CArray = struct
     assert ((sz >= n) && (sz > 0));
     assert (Int.logand sz (sz-1) == 0);
     {
-      arr  = Array.init sz (fun _ -> v);
+      arr  = Array.make sz v;
       mask = sz - 1
     }
 

--- a/lib/ws_deque.ml
+++ b/lib/ws_deque.ml
@@ -58,9 +58,11 @@ module CArray = struct
 
   let size t = Array.length t.arr [@@inline]
 
-  let get t i = Atomic.get t.arr.(Int.logand i t.mask) [@@inline]
+  let get t i =
+    Atomic.get (Array.unsafe_get t.arr (Int.logand i t.mask)) [@@inline]
 
-  let put t i v = Atomic.set t.arr.(Int.logand i t.mask) v [@@inline]
+  let put t i v =
+    Atomic.set (Array.unsafe_get t.arr (Int.logand i t.mask)) v [@@inline]
 
   let grow t top bottom =
     let s = size t in
@@ -83,7 +85,7 @@ module CArray = struct
 end
 
 module M : S = struct
-  let min_size = 16
+  let min_size = 32
   let shrink_const = 3
 
   type 'a t = {

--- a/lib/ws_deque.ml
+++ b/lib/ws_deque.ml
@@ -130,7 +130,7 @@ module M : S = struct
     let a = Atomic.get q.tab in
     let size = b - t in
     let a =
-      if size >= CArray.size a - 1 then
+      if size = CArray.size a then
         (grow q t b; Atomic.get q.tab)
       else
         a

--- a/lib/ws_deque.ml
+++ b/lib/ws_deque.ml
@@ -1,0 +1,184 @@
+(*
+ * Copyright (c) 2015, Théo Laurent <theo.laurent@ens.fr>
+ * Copyright (c) 2015, KC Sivaramakrishnan <sk826@cl.cam.ac.uk>
+ * Copyright (c) 2017, Nicolas ASSOUAD <nicolas.assouad@ens.fr>
+ * Copyright (c) 2021, Tom Kelly <ctk21@cl.cam.ac.uk>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(* Work Stealing Queue
+ *
+ * See:
+ *   Dynamic circular work-stealing deque
+ *   https://dl.acm.org/doi/10.1145/1073970.1073974
+ *  &
+ *   Correct and efficient work-stealing for weak memory models
+ *   https://dl.acm.org/doi/abs/10.1145/2442516.2442524
+ *)
+
+module type S = sig
+  type 'a t
+  val create : unit -> 'a t
+  val is_empty : 'a t -> bool
+  val size : 'a t -> int
+  val push : 'a t -> 'a -> unit
+  val pop : 'a t -> 'a option
+  val steal : 'a t -> 'a option
+end
+
+module CArray = struct
+
+  type 'a t = {
+    arr  : 'a Atomic.t array;
+    mask : int
+    }
+
+  let rec log2 n =
+    if n <= 1 then 0 else 1 + (log2 (n asr 1))
+
+  let create n v =
+    let sz = Int.shift_left 1 (log2 n) in
+    assert ((sz >= n) && (sz > 0));
+    assert (Int.logand sz (sz-1) == 0);
+    {
+      arr  = Array.init sz (fun _ -> Atomic.make v);
+      mask = sz - 1
+    }
+
+  let size t = Array.length t.arr [@@inline]
+
+  let get t i = Atomic.get t.arr.(Int.logand i t.mask) [@@inline]
+
+  let put t i v = Atomic.set t.arr.(Int.logand i t.mask) v [@@inline]
+
+  let grow t top bottom =
+    let s = size t in
+    let ns = 2 * s in
+    let out = create ns (Obj.magic ()) in
+    for i = top to bottom do
+      put out i (get t i)
+    done;
+    out
+
+  let shrink t top bottom =
+    let s = size t in
+    let ns = s / 2 in
+    let out = create ns (Obj.magic ()) in
+    for i = top to bottom do
+      put out i (get t i)
+    done;
+    out
+
+end
+
+module M : S = struct
+  let min_size = 16
+  let shrink_const = 3
+
+  type 'a t = {
+    top : int Atomic.t;
+    bottom : int Atomic.t;
+    tab : 'a CArray.t Atomic.t;
+    mutable next_shrink : int;
+  }
+
+  let create () = {
+    top = Atomic.make 0;
+    bottom = Atomic.make 0;
+    tab = Atomic.make (CArray.create min_size (Obj.magic ()));
+    next_shrink = min_size / shrink_const
+  }
+
+  let set_next_shrink q =
+    let sz = CArray.size (Atomic.get q.tab) in
+    if sz <= min_size then
+      q.next_shrink <- 0
+    else
+      q.next_shrink <- sz / shrink_const
+
+  let grow q t b =
+    Atomic.set q.tab (CArray.grow (Atomic.get q.tab) t b);
+    set_next_shrink q
+
+  let is_empty q =
+    let b = Atomic.get q.bottom in
+    let t = Atomic.get q.top in
+    b - t <= 0
+
+  let size q =
+    let b = Atomic.get q.bottom in
+    let t = Atomic.get q.top in
+    assert (b - t >= 0);
+    b - t
+
+  let push q v =
+    let b = Atomic.get q.bottom in
+    let t = Atomic.get q.top in
+    let a = Atomic.get q.tab in
+    let size = b - t in
+    let a =
+      if size >= CArray.size a - 1 then
+        (grow q t b; Atomic.get q.tab)
+      else
+        a
+    in
+    CArray.put a b v;
+    Atomic.set q.bottom (b + 1)
+
+  let pop q =
+    let b = (Atomic.get q.bottom) - 1 in
+    Atomic.set q.bottom b;
+    let t = Atomic.get q.top in
+    let a = Atomic.get q.tab in
+    let size = b - t in
+    if size < 0 then begin
+      (* empty queue *)
+      Atomic.set q.bottom (b + 1);
+      None
+    end else
+      let out = CArray.get a b in
+      if b = t then begin
+        (* single last element *)
+        if (Atomic.compare_and_set q.top t (t + 1)) then
+          (Atomic.set q.bottom (b + 1); Some out)
+        else
+          (Atomic.set q.bottom (b + 1); None)
+      end else begin
+        (* non-empty queue *)
+        if q.next_shrink > size then begin
+          Atomic.set q.tab (CArray.shrink a t b);
+          set_next_shrink q
+        end;
+        Some out
+      end
+
+  let steal q =
+    let rec loop () =
+      let t = Atomic.get q.top in
+      let b = Atomic.get q.bottom in
+      let a = Atomic.get q.tab in
+      let size = b - t in
+      if size <= 0 then
+        None
+      else
+        let out = CArray.get a t in
+        if Atomic.compare_and_set q.top t (t + 1) then
+          Some out
+        else begin
+          Domain.Sync.cpu_relax ();
+          loop ()
+        end
+    in loop ()
+
+end


### PR DESCRIPTION
This PR is an implementation of Chase Lev deques organised for task stealing; as is traditional in Cilk, Concurrent bags, etc. 

The basic idea is:
- each domain in the task pool owns a CL deque; it can call `push` without synchronous operations and `pop` will not need to synchronize with other domains unless there is only 1 element in the deque.
- if a domain has no tasks, it will `steal` tasks from randomly chosen deques belonging to other domains.
- there is a mechanism for domains to block when they discover there is no work in any queue by posting a message to a 'waiter channel'. Importantly when all domains are awake, the only extra overhead is to check that the 'waiter channel' is empty. 
- the implementation can also be tweaked to operate in a 'non-blocking' mode where you spin rather than block in the operating system by setting `recv_block_spins`. 

Early benchmarking results (detuned Zen2 with sandmark `fb2a38`) are encouraging:
![20210519_big_deque_time](https://user-images.githubusercontent.com/1682628/118842128-d57e7c00-b8c0-11eb-88ed-1dbe192a403f.png)
![20210519_big_deque_speedup](https://user-images.githubusercontent.com/1682628/118842136-d7483f80-b8c0-11eb-87b4-b392726721f7.png)

I wouldn't say the implementation is fully finished:
 - I feel we can lean on the OCaml multicore memory model more in the deque rather than wrapping every operation in an `Atomic` indirection. 
 - It might be worth making the implementation full garbage free. We could remove the `Some`/`None` return from the deque to use exceptions. 
 - While the benchmark results are good for many cases (`LU_decomposition` and `game_of_life` stand out), it would be good to understand the `matrix_multiplication` regression and take a look at the `binarytrees5` where the deques might be a bit slower. 

_The CL deque implementation was built on the [queue in lockfree](https://github.com/ocaml-multicore/lockfree/blob/69eff48e2887384e28560e948fa33ed53dddd2fc/src/lf_wsqueue.ml) but I would recommend looking at the C code in [Correct and efficient work-stealing for weak memory models](https://dl.acm.org/doi/abs/10.1145/2442516.2442524)_