### PR TITLE
Add dependency on base-domains to opam file

### DIFF
--- a/domainslib.opam
+++ b/domainslib.opam
@@ -9,6 +9,7 @@ dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
 bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
 tags: []
 depends: [
+  "base-domains"
   "ocamlfind" {build}
   "dune" {build}
 ]


### PR DESCRIPTION
This PR adds `base-domains` as an opam dependency; you need domains to compile domainslib.  