### PR TITLE
Fix initial value accounting in `parallel_for_reduce`

### DIFF
--- a/lib/task.ml
+++ b/lib/task.ml
@@ -76,7 +76,7 @@ let parallel_for_reduce ?(chunk_size=0) ~start ~finish ~body pool reduce_fun ini
         if i > e then acc
         else loop (i+1) (reduce_fun acc (body i))
       in
-      loop s init
+      loop (s+1) (body s)
     else begin
       let d = s + ((e - s) / 2) in
       let p = async pool (fun _ -> work s d) in
@@ -85,7 +85,7 @@ let parallel_for_reduce ?(chunk_size=0) ~start ~finish ~body pool reduce_fun ini
       reduce_fun left right
     end
   in
-  work start finish
+  reduce_fun init (work start finish)
 
 let parallel_for ?(chunk_size=0) ~start ~finish ~body pool =
   let chunk_size = if chunk_size > 0 then chunk_size

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -43,13 +43,13 @@ val parallel_for_reduce : ?chunk_size:int -> start:int -> finish:int ->
 (** [parallel_for_reduce c s f b p r i] is similar to [parallel_for] except
   * that the result returned by each iteration is reduced with [r] with initial
   * value [i]. The reduce operations are performed in an arbitrary order and the
-  * reduce function needs to be associative in order to obtain a deterministic
-  * result. *)
+  * reduce function needs to be commutative and associative in order to obtain 
+  * a deterministic result. *)
 
 val parallel_scan : pool -> ('a -> 'a -> 'a) -> 'a array -> 'a array
 (** [parallel_scan p op a] computes the scan of the array [a]
   * in parallel with binary operator [op] and returns the result array.
   * Scan is similar to [Array.fold_left] but returns an array of reduced
   * intermediate values. The reduce operations are performed in an arbitrary
-  * order and the reduce function needs to be associative in order to obtain a
-  * deterministic result *)
+  * order and the reduce function needs to be commutative and associative in 
+  * order to obtain a deterministic result *)

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -42,10 +42,14 @@ val parallel_for_reduce : ?chunk_size:int -> start:int -> finish:int ->
                 body:(int -> 'a) -> pool -> ('a -> 'a -> 'a) -> 'a -> 'a
 (** [parallel_for_reduce c s f b p r i] is similar to [parallel_for] except
   * that the result returned by each iteration is reduced with [r] with initial
-  * value [i]. *)
+  * value [i]. The reduce operations are performed in an arbitrary order and the
+  * reduce function needs to be associative in order to obtain a deterministic
+  * result. *)
 
 val parallel_scan : pool -> ('a -> 'a -> 'a) -> 'a array -> 'a array
 (** [parallel_scan p op a] computes the scan of the array [a]
   * in parallel with binary operator [op] and returns the result array.
   * Scan is similar to [Array.fold_left] but returns an array of reduced
-  * intermediate values *)
+  * intermediate values. The reduce operations are performed in an arbitrary
+  * order and the reduce function needs to be associative in order to obtain a
+  * deterministic result *)

--- a/test/dune
+++ b/test/dune
@@ -80,3 +80,9 @@
  (libraries domainslib unix)
  (modules prefix_sum)
  (modes native))
+
+(test
+ (name test_task)
+ (libraries domainslib)
+ (modules test_task)
+ (modes native))

--- a/test/test_task.ml
+++ b/test/test_task.ml
@@ -1,0 +1,56 @@
+(* Generic tests for the task module *)
+
+(* Parallel for *)
+
+open Domainslib
+let modify_arr pool chunk_size = fun () ->
+  let arr1 = Array.init 100 (fun i -> i + 1) in
+  Task.parallel_for ~chunk_size ~start:0 ~finish:99
+    ~body:(fun i -> arr1.(i) <- arr1.(i) * 2) pool;
+  let arr_res = Array.init 100 (fun i -> (i + 1) * 2) in
+  assert (arr1 = arr_res)
+
+let inc_ctr pool chunk_size = fun () ->
+  let ctr = Atomic.make 0 in
+  Task.parallel_for ~chunk_size ~start:1 ~finish:1000
+    ~body:(fun _ -> Atomic.incr ctr) pool;
+  assert (Atomic.get ctr = 1000)
+
+(* Parallel for reduce *)
+
+let sum_sequence pool chunk_size init = fun () ->
+  let v = Task.parallel_for_reduce ~chunk_size ~start:1
+    ~finish:100 ~body:(fun i -> i) pool (+) init in
+  assert (v = 5050 + init)
+
+(* Parallel scan *)
+
+let prefix_sum pool = fun () ->
+  let prefix_s l = List.rev (List.fold_left (fun a y -> match a with
+    | [] -> [y]
+    | x::_ -> (x+y)::a) [] l) in
+  let arr = Array.make 1000 1 in
+  let v1 = Task.parallel_scan pool (+) arr in
+  let ls = Array.to_list arr in
+  let v2 = prefix_s ls in
+  assert (v1 = Array.of_list v2)
+
+
+let () =
+  let pool = Task.setup_pool ~num_additional_domains:3 in
+  modify_arr pool 0 ();
+  modify_arr pool 25 ();
+  modify_arr pool 100 ();
+  inc_ctr pool 0 ();
+  inc_ctr pool 16 ();
+  inc_ctr pool 32 ();
+  inc_ctr pool 1000 ();
+  sum_sequence pool 0 0 ();
+  sum_sequence pool 10 10 ();
+  sum_sequence pool 1 0 ();
+  sum_sequence pool 1 10 ();
+  sum_sequence pool 100 10 ();
+  sum_sequence pool 100 100 ();
+  prefix_sum pool ();
+  Task.teardown_pool pool;
+  print_endline "ok"


### PR DESCRIPTION
This patch attempts to fix a bug reported in #33. The initial value in `parallel_for_reduce` was accounted multiple times depending on the chunk size. Now it is reduced only once after other computations are over.

This patch also includes a doc update to signal users that the order of execution in the parallel functions is non-deterministic, and includes some correctness tests for `parallel_for`, `parallel_for_reduce` and `parallel_scan`.