### PR TITLE
Switch to default Random module

### DIFF
--- a/lib/multi_channel.ml
+++ b/lib/multi_channel.ml
@@ -36,7 +36,6 @@ type 'a t = {
 type dls_state = {
   mutable id: int;
   mutable steal_offsets: int array;
-  rng_state: Random.State.t;
   mc: mutex_condvar;
 }
 
@@ -45,7 +44,6 @@ let dls_key =
     {
       id = -1;
       steal_offsets = Array.make 1 0;
-      rng_state = Random.State.make_self_init ();
       mc = {mutex=Mutex.create (); condition=Condition.create ()};
     })
 
@@ -120,7 +118,7 @@ let rec recv_poll_loop mchan dls cur_offset =
   let k = (Array.length offsets) - cur_offset in
   if k = 0 then raise Exit
   else begin
-    let idx = cur_offset + (Random.State.int dls.rng_state k) in
+    let idx = cur_offset + (Random.int k) in
     let t = Array.unsafe_get offsets idx in
     let channel = Array.unsafe_get mchan.channels (Int.logand (dls.id + t) mchan.mask) in
     try

--- a/test/LU_decomposition_multicore.ml
+++ b/test/LU_decomposition_multicore.ml
@@ -2,8 +2,6 @@ module T = Domainslib.Task
 let num_domains = try int_of_string Sys.argv.(1) with _ -> 1
 let mat_size = try int_of_string Sys.argv.(2) with _ -> 1200
 
-let k = Domain.DLS.new_key Random.State.make_self_init
-
 module SquareMatrix = struct
 
   let create f : float array =
@@ -56,7 +54,7 @@ let lup pool (a0 : float array) =
 let () =
   let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
   let a = parallel_create pool
-    (fun _ _ -> (Random.State.float (Domain.DLS.get k) 100.0) +. 1.0 ) in
+    (fun _ _ -> (Random.float 100.0) +. 1.0 ) in
   let lu = lup pool a in
   let _l = parallel_create pool (fun i j -> if i > j then get lu i j else if i = j then 1.0 else 0.0) in
   let _u = parallel_create pool (fun i j -> if i <= j then get lu i j else 0.0) in


### PR DESCRIPTION
The Random module stores its state in Domain-local storage (see https://github.com/ocaml-multicore/ocaml-multicore/pull/582), thereby making it convenient to be called from multiple domains.

Sandmark results:
![image](https://user-images.githubusercontent.com/13328130/123367893-6586a400-d598-11eb-805a-13d8eb4fff9f.png)
