### PR TITLE
Parallel map

### DIFF
--- a/lib/task.ml
+++ b/lib/task.ml
@@ -161,3 +161,11 @@ let parallel_scan pool op elements =
   prefix_s
   end
 
+
+let parallel_map pool ?(chunk_size=0) f arr =
+  let len = Array.length arr in
+  let res = Array.make len (f arr.(0)) in
+  parallel_for ~chunk_size ~start:1 ~finish:(len - 1)
+  ~body:(fun i ->
+    res.(i) <- (f arr.(i))) pool;
+  res

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -56,3 +56,6 @@ val parallel_scan : pool -> ('a -> 'a -> 'a) -> 'a array -> 'a array
 
 val parallel_map : pool -> ?chunk_size:int -> ('a -> 'b ) -> 'a array
                    -> 'b array
+(** [parallel_map p c f arr] is similar to [Array.map], but runs the computation
+  * in parallel. The [chunk_size] parameter is optional, when not provided
+  * defaults to the chunk size computed in [parallel_for] *)

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -53,3 +53,6 @@ val parallel_scan : pool -> ('a -> 'a -> 'a) -> 'a array -> 'a array
   * intermediate values. The reduce operations are performed in an arbitrary
   * order and the reduce function needs to be commutative and associative in 
   * order to obtain a deterministic result *)
+
+val parallel_map : pool -> ?chunk_size:int -> ('a -> 'b ) -> 'a array
+                   -> 'b array

--- a/test/test_task.ml
+++ b/test/test_task.ml
@@ -35,6 +35,13 @@ let prefix_sum pool n = fun () ->
   let v2 = prefix_s ls in
   assert (v1 = Array.of_list v2)
 
+let parallel_map pool chunk_size = fun () ->
+  let arr = Array.init 1000 (fun i -> i) in
+  let res_1 =
+  Task.parallel_map pool ~chunk_size (fun x -> x + 3) arr in
+  let res_2 = Array.map (fun x -> x + 3) arr in
+  assert (res_1 = res_2)
+
 let run_all pool = fun () ->
   modify_arr pool 0 ();
   modify_arr pool 25 ();
@@ -50,7 +57,10 @@ let run_all pool = fun () ->
   sum_sequence pool 100 10 ();
   sum_sequence pool 100 100 ();
   prefix_sum pool 1000 ();
-  prefix_sum pool 3 ()
+  prefix_sum pool 3 ();
+  parallel_map pool 0 ();
+  parallel_map pool 10 ();
+  parallel_map pool 100 ()
 
 let () =
   let pool = Task.setup_pool ~num_additional_domains:3 in


### PR DESCRIPTION
As discussed in #33 and #37. This includes an optional chunk size parameter in case people wanted more granularity.

This patch includes #39 to maintain uniformity in `test_task.ml`. Those changes are not relevant as far as this one's concerned.