### PR TITLE
Use the master branch in the link to usage examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The supported data structures are:
   + Work-stealing task pool with async/await parallelism and parallel for loop.
 
 See
-[examples](https://github.com/ocaml-multicore/domainslib/tree/task_pool/test)
+[examples](https://github.com/ocaml-multicore/domainslib/tree/master/test)
 for usage.
 
 ## Installation


### PR DESCRIPTION
The README links to sample programs in the `task_pool` branch which is outdated and examples won't run, e.g. because they use the old `num_domains` rather than the new `num_additional_domains` argument label.