### PR TITLE
remove `Domain.Sync.poll` calls

### DIFF
--- a/lib/multi_channel.ml
+++ b/lib/multi_channel.ml
@@ -86,7 +86,6 @@ let clear_local_state () =
   dls_state.id <- (-1)
 
 let rec check_waiters mchan =
-  Domain.Sync.poll (); (* need to make sure we have a safepoint in here *)
   match Chan.recv_poll mchan.waiters with
     | None -> ()
     | Some (status, mc) ->
@@ -115,7 +114,6 @@ let send mchan v =
   check_waiters mchan
 
 let rec recv_poll_loop mchan dls cur_offset =
-  Domain.Sync.poll (); (* need to make sure we have a safepoint in here *)
   let offsets = dls.steal_offsets in
   let k = (Array.length offsets) - cur_offset in
   if k = 0 then raise Exit
@@ -135,7 +133,6 @@ let rec recv_poll_loop mchan dls cur_offset =
   end
 
 let recv_poll_with_dls mchan dls =
-  Domain.Sync.poll (); (* need to make sure we have a safepoint in here *)
   try
     Ws_deque.pop (Array.unsafe_get mchan.channels dls.id)
   with

--- a/test/task_throughput.ml
+++ b/test/task_throughput.ml
@@ -47,9 +47,6 @@ module TimingHist = struct
 
 end
 
-
-let work _ = Domain.Sync.poll ()
-
 let _ =
   Printf.printf "n_iterations: %d   n_units: %d  n_domains: %d\n"
     n_iterations n_tasks n_domains;
@@ -58,7 +55,7 @@ let _ =
   let hist = TimingHist.make 5 25 in
   for _ = 1 to n_iterations do
     let t0 = Domain.timer_ticks () in
-    T.parallel_for pool ~start:1 ~finish:n_tasks ~body:work;
+    T.parallel_for pool ~start:1 ~finish:n_tasks ~body:(fun _ -> ());
     let t = Int64.sub (Domain.timer_ticks ()) t0 in
     TimingHist.add_point hist (Int64.to_int t);
   done;


### PR DESCRIPTION
https://github.com/ocaml-multicore/ocaml-multicore/pull/573 deprecates `Domain.Sync.poll`