### PR TITLE
named pools & a default global pool

### DIFF
--- a/test/LU_decomposition_multicore.ml
+++ b/test/LU_decomposition_multicore.ml
@@ -12,15 +12,15 @@ module SquareMatrix = struct
       fa.(i) <- f (i / mat_size) (i mod mat_size)
     done;
     fa
-  let parallel_create pool f : float array =
+  let parallel_create f : float array =
     let fa = Array.create_float (mat_size * mat_size) in
-    T.parallel_for pool ~start:0 ~finish:( mat_size * mat_size - 1)
-      ~body:(fun i -> fa.(i) <- f (i / mat_size) (i mod mat_size));
+    T.parallel_for ~start:0 ~finish:( mat_size * mat_size - 1)
+      ~body:(fun i -> fa.(i) <- f (i / mat_size) (i mod mat_size)) ();
     fa
 
   let get (m : float array) r c = m.(r * mat_size + c)
   let set (m : float array) r c v = m.(r * mat_size + c) <- v
-  let parallel_copy pool a =
+  let parallel_copy a =
     let n = Array.length a in
     let copy_part a b i =
       let s = (i * n / num_domains) in
@@ -29,9 +29,9 @@ module SquareMatrix = struct
     let b = Array.create_float n in
     let rec aux acc num_domains i =
       if (i = num_domains) then
-        (List.iter (fun e -> T.await pool e) acc)
+        (List.iter (fun e -> T.await e) acc)
       else begin
-        aux ((T.async pool (fun _ -> copy_part a b i))::acc) num_domains (i+1)
+        aux ((T.async (fun _ -> copy_part a b i))::acc) num_domains (i+1)
       end
     in
     aux [] num_domains 0;
@@ -40,24 +40,23 @@ end
 
 open SquareMatrix
 
-let lup pool (a0 : float array) =
-  let a = parallel_copy pool a0 in
+let lup (a0 : float array) =
+  let a = parallel_copy a0 in
   for k = 0 to (mat_size - 2) do
-  T.parallel_for pool ~start:(k + 1) ~finish:(mat_size  -1)
+  T.parallel_for ~start:(k + 1) ~finish:(mat_size  -1)
   ~body:(fun row ->
     let factor = get a row k /. get a k k in
     for col = k + 1 to mat_size-1 do
       set a row col (get a row col -. factor *. (get a k col))
       done;
-    set a row k factor )
+    set a row k factor ) ()
   done ;
   a
 
 let () =
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
-  let a = parallel_create pool
+  let a = parallel_create
     (fun _ _ -> (Random.State.float (Domain.DLS.get k) 100.0) +. 1.0 ) in
-  let lu = lup pool a in
-  let _l = parallel_create pool (fun i j -> if i > j then get lu i j else if i = j then 1.0 else 0.0) in
-  let _u = parallel_create pool (fun i j -> if i <= j then get lu i j else 0.0) in
-  T.teardown_pool pool
+  let lu = lup a in
+  let _l = parallel_create (fun i j -> if i > j then get lu i j else if i = j then 1.0 else 0.0) in
+  let _u = parallel_create (fun i j -> if i <= j then get lu i j else 0.0) in
+  T.Pool.teardown_default_pool ()

--- a/test/enumerate_par.ml
+++ b/test/enumerate_par.ml
@@ -4,7 +4,6 @@ let n = try int_of_string Sys.argv.(2) with _ -> 100
 module T = Domainslib.Task
 
 let _ =
-  let p = T.setup_pool ~num_additional_domains:(num_domains - 1) in
-  T.parallel_for p ~start:0 ~finish:(n-1) ~chunk_size:16 ~body:(fun i ->
-    print_string @@ Printf.sprintf "[%d] %d\n%!" (Domain.self () :> int) i);
-  T.teardown_pool p
+  T.parallel_for ~start:0 ~finish:(n-1) ~chunk_size:16 ~body:(fun i ->
+    print_string @@ Printf.sprintf "[%d] %d\n%!" (Domain.self () :> int) i) ();
+  T.Pool.teardown_default_pool ();

--- a/test/fib_par.ml
+++ b/test/fib_par.ml
@@ -7,15 +7,14 @@ let rec fib n =
   if n < 2 then 1
   else fib (n-1) + fib (n-2)
 
-let rec fib_par pool n =
+let rec fib_par n =
   if n <= 40 then fib n
   else
-    let a = T.async pool (fun _ -> fib_par pool (n-1)) in
-    let b = T.async pool (fun _ -> fib_par pool (n-2)) in
-    T.await pool a + T.await pool b
+    let a = T.async (fun _ -> fib_par (n-1)) in
+    let b = T.async (fun _ -> fib_par (n-2)) in
+    T.await a + T.await b
 
 let main =
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
-  let res = fib_par pool n in
-  T.teardown_pool pool;
+  let res = fib_par n in
+  T.Pool.teardown_default_pool ();
   Printf.printf "fib(%d) = %d\n" n res

--- a/test/game_of_life_multicore.ml
+++ b/test/game_of_life_multicore.ml
@@ -44,26 +44,25 @@ let print g =
   done;
   print_endline ""
 
-let next pool =
+let next () =
   let g = !rg in
   let new_g = !rg' in
-  T.parallel_for pool ~start:0
+  T.parallel_for ~start:0
     ~finish:(board_size - 1) ~body:(fun x ->
       for y = 0 to board_size - 1 do
         new_g.(x).(y) <- next_cell g x y
-      done);
+      done) ();
   rg := new_g;
   rg' := g
 
 
-let rec repeat pool n =
+let rec repeat n =
   match n with
   | 0-> ()
-  | _-> next pool; repeat pool (n-1)
+  | _-> next (); repeat (n-1)
 
 let ()=
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
   print !rg;
-  repeat pool n_times;
+  repeat n_times;
   print !rg;
-  T.teardown_pool pool
+  T.Pool.teardown_default_pool ()

--- a/test/prefix_sum.ml
+++ b/test/prefix_sum.ml
@@ -4,12 +4,11 @@ let n = try int_of_string Sys.argv.(2) with _ -> 100000
 
 let gen n = Array.make n 1 (*(fun _ -> Random.int n)*)
 
-let prefix_sum pool = T.parallel_scan pool (+)
+let prefix_sum = T.parallel_scan (+)
 
 let _ =
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
   let arr = gen n in
   let t = Unix.gettimeofday() in
-  let _ = prefix_sum pool arr in
+  let _ = prefix_sum arr in
   Printf.printf "Execution time: %fs\n" (Unix.gettimeofday() -. t);
-  T.teardown_pool pool
+  T.Pool.teardown_default_pool

--- a/test/sum_par.ml
+++ b/test/sum_par.ml
@@ -7,8 +7,8 @@ let _ =
   (* use parallel_for_reduce *)
   let p = T.setup_pool ~num_additional_domains:(num_domains - 1) in
   let sum =
-    T.parallel_for_reduce p (+) 0 ~chunk_size:(n/(4*num_domains)) ~start:0
-      ~finish:(n-1) ~body:(fun _i -> 1)
+    T.parallel_for_reduce ~pool:p (+) 0 ~chunk_size:(n/(4*num_domains)) ~start:0
+      ~finish:(n-1) ~body:(fun _ -> 1)
   in
   T.teardown_pool p;
   Printf.printf "Sum is %d\n" sum;
@@ -18,8 +18,8 @@ let _ =
   (* explictly use empty pool and default chunk_size *)
   let p = T.setup_pool ~num_additional_domains:0 in
   let sum = Atomic.make 0 in
-  T.parallel_for p ~start:0 ~finish:(n-1)
-      ~body:(fun _i -> ignore (Atomic.fetch_and_add sum 1));
+  T.parallel_for ~pool:p ~start:0 ~finish:(n-1)
+      ~body:(fun _i -> ignore (Atomic.fetch_and_add sum 1)) ();
   let sum = Atomic.get sum in
   T.teardown_pool p;
   Printf.printf "Sum is %d\n" sum;
@@ -29,8 +29,8 @@ let _ =
   (* configured num_domains and default chunk_size *)
   let p = T.setup_pool ~num_additional_domains:(num_domains - 1) in
   let sum = Atomic.make 0 in
-  T.parallel_for p ~start:0 ~finish:(n-1)
-      ~body:(fun _i -> ignore (Atomic.fetch_and_add sum 1));
+  T.parallel_for ~pool:p ~start:0 ~finish:(n-1)
+      ~body:(fun _i -> ignore (Atomic.fetch_and_add sum 1)) ();
   let sum = Atomic.get sum in
   T.teardown_pool p;
   Printf.printf "Sum is %d\n" sum;

--- a/test/summed_area_table.ml
+++ b/test/summed_area_table.ml
@@ -13,24 +13,23 @@ let transpose a =
   done;
   b
 
-let calc_table pool mat =
+let calc_table mat =
   let l = Array.length mat in
   let res = Array.copy mat in
   for i = 0 to (l - 1) do
-    res.(i) <- T.parallel_scan pool (fun x y -> x + y) mat.(i)
+    res.(i) <- T.parallel_scan (fun x y -> x + y) mat.(i)
   done;
   let k = transpose res in
 
   for i = 0 to (l - 1) do
-    res.(i) <- T.parallel_scan pool (fun x y -> x + y) k.(i)
+    res.(i) <- T.parallel_scan (fun x y -> x + y) k.(i)
   done;
   (transpose res)
 
 let _ =
   let m = Array.make_matrix size size 1 (*Array.init size (fun _ -> Array.init size (fun _ -> Random.int size))*)
   in
-  let pool = T.setup_pool ~num_additional_domains:(num_domains - 1) in
-  let _ = calc_table pool m in
+  let _ = calc_table m in
 
   (* for i = 0 to size-1 do
     for j = 0 to size-1 do
@@ -38,4 +37,4 @@ let _ =
     done;
     print_newline()
   done; *)
-  T.teardown_pool pool
+  T.Pool.teardown_default_pool ()

--- a/test/task_exn.ml
+++ b/test/task_exn.ml
@@ -3,27 +3,25 @@ module T = Domainslib.Task
 exception E
 
 let _ =
-  let pool = T.setup_pool ~num_additional_domains:3 in
-
-  let p1 = T.async pool (fun () ->
-    let p2 = T.async pool (fun () -> raise E) in
-    T.await pool p2)
+  let p1 = T.async  (fun () ->
+    let p2 = T.async (fun () -> raise E) in
+    T.await p2)
   in
-  begin match T.await pool p1 with
+  begin match T.await p1 with
   | _ -> ()
   | exception E -> print_endline "Caught E"
   end;
 
-  let _p1 = T.async pool (fun () ->
-    let p2 = T.async pool (fun () ->
+  let _p1 = T.async (fun () ->
+    let p2 = T.async (fun () ->
       let rec loop n =
         if n = 0 then ()
         else loop (n-1)
       in loop 100000000)
     in
-    T.await pool p2)
+    T.await p2)
   in
-  match T.teardown_pool pool with
+  match T.Pool.teardown_default_pool () with
   | _ -> ()
   | exception T.TasksActive ->
       (* innermost task may still be active *)

--- a/test/task_throughput.ml
+++ b/test/task_throughput.ml
@@ -48,6 +48,7 @@ module TimingHist = struct
 end
 
 let _ =
+  T.Pool.teardown_default_pool ();
   Printf.printf "n_iterations: %d   n_units: %d  n_domains: %d\n"
     n_iterations n_tasks n_domains;
   let pool = T.setup_pool ~num_additional_domains:(n_domains - 1) in
@@ -55,7 +56,7 @@ let _ =
   let hist = TimingHist.make 5 25 in
   for _ = 1 to n_iterations do
     let t0 = Domain.timer_ticks () in
-    T.parallel_for pool ~start:1 ~finish:n_tasks ~body:(fun _ -> ());
+    T.parallel_for ~pool ~start:1 ~finish:n_tasks ~body:(fun _ -> ()) ();
     let t = Int64.sub (Domain.timer_ticks ()) t0 in
     TimingHist.add_point hist (Int64.to_int t);
   done;

--- a/test/test_task.ml
+++ b/test/test_task.ml
@@ -3,54 +3,53 @@
 (* Parallel for *)
 
 open Domainslib
-let modify_arr pool chunk_size = fun () ->
+let modify_arr  chunk_size = fun () ->
   let arr1 = Array.init 100 (fun i -> i + 1) in
   Task.parallel_for ~chunk_size ~start:0 ~finish:99
-    ~body:(fun i -> arr1.(i) <- arr1.(i) * 2) pool;
+    ~body:(fun i -> arr1.(i) <- arr1.(i) * 2) ();
   let arr_res = Array.init 100 (fun i -> (i + 1) * 2) in
   assert (arr1 = arr_res)
 
-let inc_ctr pool chunk_size = fun () ->
+let inc_ctr  chunk_size = fun () ->
   let ctr = Atomic.make 0 in
   Task.parallel_for ~chunk_size ~start:1 ~finish:1000
-    ~body:(fun _ -> Atomic.incr ctr) pool;
+    ~body:(fun _ -> Atomic.incr ctr) ();
   assert (Atomic.get ctr = 1000)
 
 (* Parallel for reduce *)
 
-let sum_sequence pool chunk_size init = fun () ->
+let sum_sequence  chunk_size init = fun () ->
   let v = Task.parallel_for_reduce ~chunk_size ~start:1
-    ~finish:100 ~body:(fun i -> i) pool (+) init in
+    ~finish:100 ~body:(fun i -> i)  (+) init in
   assert (v = 5050 + init)
 
 (* Parallel scan *)
 
-let prefix_sum pool = fun () ->
+let prefix_sum  = fun () ->
   let prefix_s l = List.rev (List.fold_left (fun a y -> match a with
     | [] -> [y]
     | x::_ -> (x+y)::a) [] l) in
   let arr = Array.make 1000 1 in
-  let v1 = Task.parallel_scan pool (+) arr in
+  let v1 = Task.parallel_scan  (+) arr in
   let ls = Array.to_list arr in
   let v2 = prefix_s ls in
   assert (v1 = Array.of_list v2)
 
 
 let () =
-  let pool = Task.setup_pool ~num_additional_domains:3 in
-  modify_arr pool 0 ();
-  modify_arr pool 25 ();
-  modify_arr pool 100 ();
-  inc_ctr pool 0 ();
-  inc_ctr pool 16 ();
-  inc_ctr pool 32 ();
-  inc_ctr pool 1000 ();
-  sum_sequence pool 0 0 ();
-  sum_sequence pool 10 10 ();
-  sum_sequence pool 1 0 ();
-  sum_sequence pool 1 10 ();
-  sum_sequence pool 100 10 ();
-  sum_sequence pool 100 100 ();
-  prefix_sum pool ();
-  Task.teardown_pool pool;
+  modify_arr  0 ();
+  modify_arr  25 ();
+  modify_arr  100 ();
+  inc_ctr  0 ();
+  inc_ctr  16 ();
+  inc_ctr  32 ();
+  inc_ctr  1000 ();
+  sum_sequence  0 0 ();
+  sum_sequence  10 10 ();
+  sum_sequence  1 0 ();
+  sum_sequence  1 10 ();
+  sum_sequence  100 10 ();
+  sum_sequence  100 100 ();
+  prefix_sum  ();
+  Task.Pool.teardown_default_pool ();
   print_endline "ok"


### PR DESCRIPTION
Named pools allows storing multiple pools and referencing them later on. This would be useful for sparing certain domains for specific tasks.

This patch also introduces a global default task pool, which effectively makes pool an optional parameter in all the task functions. This aims to simplify parallel code by not having to pass around pool. It also aims to make introducing parallelism in existing codebases easier.

This is an initial cut, any opinions and ideas for improvement are welcome!