### PR TITLE
Make domainslib build/run with OCaml 5.00 after PR #704

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
           cache-prefix: ${{ steps.multicore_hash.outputs.commit }}
 
-      - run: opam install . --deps-only
+      - run: opam install . --deps-only --with-test
 
       - run: opam exec -- make all
 

--- a/domainslib.opam
+++ b/domainslib.opam
@@ -12,6 +12,7 @@ depends: [
   "base-domains"
   "ocamlfind" {build}
   "dune" {build}
+  "mirage-clock-unix" {with-test}
 ]
 depopts: []
 build: [

--- a/lib/multi_channel.ml
+++ b/lib/multi_channel.ml
@@ -149,7 +149,7 @@ let rec recv_poll_repeated mchan dls repeats =
     | Exit ->
       if repeats = 1 then raise Exit
       else begin
-        Domain.Sync.cpu_relax ();
+        Domain.cpu_relax ();
         recv_poll_repeated mchan dls (repeats - 1)
       end
 

--- a/lib/task.ml
+++ b/lib/task.ml
@@ -75,7 +75,7 @@ let rec await pool promise =
           | Task (t, p) -> do_task t p
           | Quit -> raise TasksActive
         with
-        | Exit -> Domain.Sync.cpu_relax ()
+        | Exit -> Domain.cpu_relax ()
       end;
       await pool promise
   | Some (Ok v) -> v

--- a/lib/ws_deque.ml
+++ b/lib/ws_deque.ml
@@ -189,7 +189,7 @@ module M : S = struct
       if Atomic.compare_and_set q.top t (t + 1) then
         release out
       else begin
-        Domain.Sync.cpu_relax ();
+        Domain.cpu_relax ();
         steal q
       end
 

--- a/test/dune
+++ b/test/dune
@@ -59,7 +59,7 @@
 
 (test
  (name task_throughput)
- (libraries domainslib)
+ (libraries domainslib mirage-clock-unix)
  (modules task_throughput)
  (modes native))
 

--- a/test/task_throughput.ml
+++ b/test/task_throughput.ml
@@ -54,9 +54,9 @@ let _ =
 
   let hist = TimingHist.make 5 25 in
   for _ = 1 to n_iterations do
-    let t0 = Domain.timer_ticks () in
+    let t0 = Mclock.elapsed_ns() in
     T.parallel_for pool ~start:1 ~finish:n_tasks ~body:(fun _ -> ());
-    let t = Int64.sub (Domain.timer_ticks ()) t0 in
+    let t = Int64.sub (Mclock.elapsed_ns ()) t0 in
     TimingHist.add_point hist (Int64.to_int t);
   done;
 


### PR DESCRIPTION
Updated CI to use opam repo @ https://github.com/kit-ty-kate/multicore-opam. So that we can use the ocaml 5.00 switch. (4.14.0+domains). 

This will probably need to be reverted to original multicore-opam once the changes from kit-ty-kate is merged. 

~~Note: After this PR is merged domainslib will be  incompatible with `4.12.0+domains` switch. We need to cherry pick PR#704 from 5.00 branch to 4.12.0+domains branch.~~ The latter is no longer the case after https://github.com/ocaml-multicore/ocaml-multicore/pull/718