### PR TITLE
use last 4.12+domains+effects hash as the cache-key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Generate random number
-        id: random
-        shell: pwsh
-        run: Write-Output "::set-output name=number::$(Get-Random)"
+      - name: Get latest Multicore commit hash
+        id: multicore_hash
+        shell: bash
+        run: |
+          curl -sH "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/ocaml-multicore/ocaml-multicore/commits/4.12+domains+effects \
+          | jq .commit.tree.sha | xargs printf '::set-output name=commit::%s'
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
@@ -36,7 +39,7 @@ jobs:
           opam-repositories: |
             multicore: https://github.com/ocaml-multicore/multicore-opam.git
             default: https://github.com/ocaml/opam-repository.git
-          cache-prefix: ${{ steps.random.outputs.number }}
+          cache-prefix: ${{ steps.multicore_hash.outputs.commit }}
 
       - run: opam install . --deps-only
 


### PR DESCRIPTION
This PR implements @dra27's (thanks!) suggestion to use the last commit hash from Multicore as the cache-key in order to invalidate the cache when we make change to Multicore. (which is less heavy handed than a random seed.)