### PR TITLE
Fix Task.parallel_for_reduce on empty loop

### DIFF
--- a/lib/task.ml
+++ b/lib/task.ml
@@ -177,7 +177,9 @@ let parallel_for_reduce ?(chunk_size=0) ~start ~finish ~body pool reduce_fun ini
       reduce_fun left right
     end
   in
-  reduce_fun init (work start finish)
+  if finish < start
+  then init
+  else reduce_fun init (work start finish)
 
 let parallel_for ?(chunk_size=0) ~start ~finish ~body pool =
   let pd = get_pool_data pool in

--- a/test/dune
+++ b/test/dune
@@ -94,6 +94,12 @@
  (modes native))
 
 (test
+ (name test_task_empty)
+ (libraries domainslib)
+ (modules test_task_empty)
+ (modes native))
+
+(test
  (name backtrace)
  (libraries domainslib)
  (modules backtrace)

--- a/test/test_task_empty.ml
+++ b/test/test_task_empty.ml
@@ -1,0 +1,9 @@
+open Domainslib
+
+let array_size = 0
+
+let pool = Task.setup_pool ~num_additional_domains:0 ()
+let res = Task.run pool (fun () ->
+    Task.parallel_for_reduce ~chunk_size:0 ~start:0 ~finish:(array_size-1) ~body:(fun _ -> 1) pool (+) 0);;
+Task.teardown_pool pool;;
+assert(res = array_size)


### PR DESCRIPTION
`Task.parallel_for_reduce` gives the wrong result for the corner-case of an empty loop with `start:0` and `finish:-1`.
For a simple (in this case: empty) loop that adds an array of 1s, it returns `1` rather than the expected `init = 0`.

The current code builds on a reasonable assumption of non-empty parallel loops.
The PR tests for the corner-case only once per invocation ("at top-level")
and hence should not affect the performance of such loops noticeably.