### PR TITLE
Make Chan.t and Task.promise injective

### DIFF
--- a/lib/chan.mli
+++ b/lib/chan.mli
@@ -1,4 +1,4 @@
-type 'a t
+type !'a t
 (** The type of channels *)
 
 val make_bounded : int -> 'a t

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -1,7 +1,7 @@
 type 'a task = unit -> 'a
 (** Type of task *)
 
-type 'a promise
+type !'a promise
 (** Type of promises *)
 
 type pool


### PR DESCRIPTION
The injectivity annotations will make these type constructors immediately usable as indexes of GADTs. In particular, the GADT `Effect.t`.