### PR TITLE
Add settable promise

### DIFF
--- a/lib/task.mli
+++ b/lib/task.mli
@@ -54,6 +54,10 @@ val await : pool -> 'a promise -> 'a
     Must be called with a call to {!run} in the dynamic scope to handle the
     internal algebraic effects for task synchronization. *)
 
+val promise : unit -> 'a promise * ('a -> unit)
+(** [promise ()] returns a new promise and a function to resolve it
+    to a value. The function can only be called once. *)
+
 val parallel_for : ?chunk_size:int -> start:int -> finish:int ->
                    body:(int -> unit) -> pool -> unit
 (** [parallel_for c s f b p] behaves similar to [for i=s to f do b i done], but

--- a/test/bench_mpmc_queue.ml
+++ b/test/bench_mpmc_queue.ml
@@ -1,0 +1,85 @@
+module T = Domainslib.Task
+module Q = Mpmc_queue
+
+let nb = 1_000_000
+
+module type CHAN = sig
+  type 'a t
+  val make : unit -> 'a t
+  val send : 'a t -> 'a -> unit
+  val recv : pool:T.pool -> 'a t -> 'a
+end
+
+module Bench (C : CHAN) = struct
+
+  let test ~pool () =
+    let t = C.make () in
+    let _ =
+      T.async pool @@ fun () ->
+      T.parallel_for pool ~start:1 ~finish:nb ~body:(fun i ->
+        C.send t i
+      )
+    in
+    T.parallel_for pool ~start:1 ~finish:nb ~body:(fun _ ->
+      ignore (C.recv ~pool t)
+    )
+
+  let run num_domains =
+    let pool = T.setup_pool ~num_domains () in
+    T.run pool (test ~pool) ;
+    T.teardown_pool pool
+
+  let run () =
+    for i = 1 to 8 do
+      let t0 = Unix.gettimeofday () in
+      run i ;
+      let t1 = Unix.gettimeofday () in
+      Format.printf "  %7s%!"
+        (Printf.sprintf "%.2f" (1000.0 *. (t1 -. t0)))
+    done ;
+    Format.printf "@."
+
+end
+
+module Bench_mpmc_pool = Bench (struct
+  module Q = Mpmc_queue
+  type 'a t = 'a Q.t
+  let make () = Q.make ()
+  let send t v = Q.push t v
+  let recv ~pool t = Q.await_pop ~pool t
+end)
+
+module Bench_mpmc_retry = Bench (struct
+  module Q = Mpmc_queue
+  type 'a t = 'a Q.t
+  let make () = Q.make ()
+  let send t v = Q.push t v
+  let rec recv ~pool t =
+    match Q.pop t with
+    | Some v -> v
+    | None ->
+        Domain.cpu_relax () ;
+        recv ~pool t
+end)
+
+module Bench_chan = Bench (struct
+  module C = Domainslib.Chan
+  type 'a t = 'a C.t
+  let make () = C.make_unbounded ()
+  let send t v = C.send t v
+  let recv ~pool:_ t = C.recv t
+end)
+
+let () =
+  Format.printf "@." ;
+  Format.printf "num_domains: " ;
+  for i = 1 to 8 do
+    Format.printf " %5i   " i
+  done ;
+  Format.printf "@." ;
+  Format.printf "  Mpmc_pool: " ;
+  Bench_mpmc_pool.run () ;
+  Format.printf " Mpmc_retry: " ;
+  Bench_mpmc_retry.run () ;
+  Format.printf "       Chan: " ;
+  Bench_chan.run ()

--- a/test/dune
+++ b/test/dune
@@ -5,6 +5,12 @@
  (modes native))
 
 (test
+ (name bench_mpmc_queue)
+ (libraries domainslib unix)
+ (modules mpmc_queue bench_mpmc_queue)
+ (modes native))
+
+(test
  (name fib)
  (modules fib)
  (modes native))

--- a/test/mpmc_queue.ml
+++ b/test/mpmc_queue.ml
@@ -1,0 +1,186 @@
+let default_capacity = 4096
+let spinlock_iterations = 16
+
+type 'a cell =
+  | Empty
+  | Tombstone
+  | Value of 'a
+  | Await of ('a -> unit)
+
+type 'a s =
+  { buffer : 'a cell Atomic.t array
+  ; head : int Atomic.t
+  ; tail : int Atomic.t
+  ; rest : 'a s option Atomic.t
+  }
+
+type 'a t =
+  { first : 'a s Atomic.t
+  ; last : 'a s Atomic.t
+  }
+
+let make_s ~capacity () =
+  { head = Atomic.make 0
+  ; tail = Atomic.make (-1)
+  ; buffer = Array.init capacity (fun _ -> Atomic.make Empty)
+  ; rest = Atomic.make None
+  }
+
+let make ?(capacity = default_capacity) () =
+  let s = make_s ~capacity () in
+  { first = Atomic.make s
+  ; last = Atomic.make s
+  }
+
+let rec gift_rest t some_s =
+  if Atomic.compare_and_set t.rest None some_s
+  then ()
+  else follow_rest t some_s
+
+and follow_rest t some_s =
+  match Atomic.get t.rest with
+  | None -> gift_rest t some_s
+  | Some t -> follow_rest t some_s
+
+let force_rest t =
+  match Atomic.get t.rest with
+  | Some s -> s
+  | None ->
+      let s = make_s ~capacity:(Array.length t.buffer) () in
+      let some_s = Some s in
+      if Atomic.compare_and_set t.rest None some_s
+      then s
+      else match Atomic.get t.rest with
+           | None -> assert false
+           | Some rest ->
+              gift_rest rest some_s ;
+              rest
+
+let rec push_s t x =
+  let i = Atomic.fetch_and_add t.tail 1 in
+  if i < 0
+  then (let _ = force_rest t in push_s t x)
+  else if i >= Array.length t.buffer
+  then false
+  else begin
+    let cell = Array.unsafe_get t.buffer i in
+    match Atomic.get cell with
+    | Empty ->
+        if Atomic.compare_and_set cell Empty (Value x)
+        then true
+        else begin match Atomic.get cell with
+          | Tombstone -> push_s t x
+          | (Await fn) as old ->
+              assert (Atomic.compare_and_set cell old Tombstone) ;
+              fn x ;
+              true
+          | _ -> assert false
+        end
+    | (Await fn) as old ->
+        assert (Atomic.compare_and_set cell old Tombstone) ;
+        fn x ;
+        true
+    | Tombstone ->
+        push_s t x
+    | Value _ -> assert false
+  end
+
+let rec push t x =
+  let last = Atomic.get t.last in
+  if push_s last x
+  then ()
+  else begin
+    let rest = force_rest last in
+    let _ : bool = Atomic.compare_and_set t.last last rest in
+    push t x
+  end
+
+
+type 'a pop_result =
+  | Is_empty
+  | Wait_for_it
+  | Pop of 'a
+
+let rec pop_s t =
+  let current_head = Atomic.get t.head in
+  if current_head >= Array.length t.buffer
+  then Is_empty
+  else if current_head >= Atomic.get t.tail
+  then Wait_for_it
+  else
+    let i = Atomic.fetch_and_add t.head 1 in
+    if i >= Array.length t.buffer
+    then Is_empty
+    else
+      let cell = Array.unsafe_get t.buffer i in
+      if i >= Atomic.get t.tail
+      then tombstone t cell
+      else spinlock ~retry:spinlock_iterations t cell
+
+and tombstone t cell =
+  if Atomic.compare_and_set cell Empty Tombstone
+  then pop_s t
+  else begin match Atomic.get cell with
+       | (Value v) as old ->
+           assert (Atomic.compare_and_set cell old Tombstone) ;
+           Pop v
+       | _ -> assert false
+       end
+
+and spinlock ~retry t cell =
+  match Atomic.get cell with
+  | (Value v) as old ->
+      assert (Atomic.compare_and_set cell old Tombstone) ;
+      Pop v
+  | Empty when retry <= 0 ->
+      tombstone t cell
+  | Empty ->
+      Domain.cpu_relax () ;
+      spinlock ~retry:(retry - 1) t cell
+  | Tombstone | Await _ ->
+      assert false
+
+let rec pop t =
+  let first = Atomic.get t.first in
+  match pop_s first with
+  | Pop v -> Some v
+  | Wait_for_it -> None
+  | Is_empty ->
+      begin match Atomic.get first.rest with
+      | None -> None
+      | Some rest ->
+          let _ : bool = Atomic.compare_and_set t.first first rest in
+          pop t
+      end
+
+
+let await_pop_s ~pool t =
+  let i = Atomic.fetch_and_add t.head 1 in
+  if i >= Array.length t.buffer
+  then None
+  else
+    let cell = Array.unsafe_get t.buffer i in
+    match Atomic.get cell with
+    | (Value v) as old ->
+        assert (Atomic.compare_and_set cell old Tombstone) ;
+        Some v
+    | Empty ->
+        let promise, set_promise = Domainslib.Task.promise () in
+        if Atomic.compare_and_set cell Empty (Await set_promise)
+        then Some (Domainslib.Task.await pool promise)
+        else begin match Atomic.get cell with
+             | (Value v) as old ->
+                assert (Atomic.compare_and_set cell old Tombstone) ;
+                Some v
+             | _ -> assert false
+             end
+    | Tombstone | Await _ -> assert false
+
+let rec await_pop ~pool t =
+  let first = Atomic.get t.first in
+  match await_pop_s ~pool first with
+  | Some v -> v
+  | None ->
+      let rest = force_rest first in
+      let _ : bool = Atomic.compare_and_set t.first first rest in
+      await_pop ~pool t

--- a/test/mpmc_queue.mli
+++ b/test/mpmc_queue.mli
@@ -1,0 +1,22 @@
+(** Multi-producer, multi-consummer, thread-safe unbounded queue. *)
+
+type 'a t
+(** A queue of items of type ['a]. *)
+
+val make : ?capacity:int -> unit -> 'a t
+(** [make ()] creates a new empty queue.
+
+    The optional parameter [?capacity] defaults to 4096 and is used to size the
+    internal buffers of the queue: Choosing a small number lower the pause
+    durations caused by allocations, but a larger capacity provides overall
+    faster operations. *)
+
+val push : 'a t -> 'a -> unit
+(** [push t x] adds [x] to the tail of the queue. *)
+
+val pop : 'a t -> 'a option
+(** [pop t] removes the head item from [t] and returns it.
+    Returns [None] if [t] is currently empty. *)
+
+val await_pop : pool:Domainslib.Task.pool -> 'a t -> 'a
+(** [pop t] removes the head item from [t] and returns it. *)


### PR DESCRIPTION
Another question mark, I'm not sure that this PR fits with `domainslib` general design.

I was playing with a [lockfree MPMC queue](https://github.com/ocaml-multicore/lockfree/pull/35) and noticed that it would work well as a substitute for domainslib's Chan. The only catch is "what to do when the queue is empty and we want to pop?", because I would prefer to suspend only the current task, and not lock the current domain entirely as it could go do other stuff in the mean time. The simplest synchronization primitive I could think of is a mutable promise, such that the `pop` task can await it and the matching `push` will resolve it.

- I didn't actually replace `Chan` just yet, because it is currently independent from `Task` and either module can be used without the other -- is this intended or would it make sense to specialize `Chan` to maximize performances when used with tasks?

A small benchmark to demonstrate that the proposed API yields more stable performances than the alternatives:

```
num_domains:      1        2        3        4        5        6        7        8   
  Mpmc_pool:     57.88    63.12    52.85    61.69    51.93    52.57    64.47   394.69  <-- uses the new Task.promise
 Mpmc_retry:     60.60    71.01    83.98   110.93   202.37   155.83   192.37  1650.86  <-- uses spinlock, same impl as above
       Chan:    178.39   259.55   349.11   415.49   417.29   625.99   634.01  1221.45  <-- Domainslib.Chan
```

(`num_domains` is actually "+ 1" hence the drop at 9 domains :/)

(cc @bartoszmodelski in case you have some thoughts on this! ^^)