### PR TITLE
Improve docs presentation

### DIFF
--- a/lib/chan.mli
+++ b/lib/chan.mli
@@ -3,30 +3,30 @@ type !'a t
 
 val make_bounded : int -> 'a t
 (** [make_bounded n] makes a bounded channel with a buffer of size [n]. Raises
- * [Invalid_argument "Chan.make_bounded"] if the buffer size is less than 0.
- *
- * With a buffer size of 0, the send operation becomes synchronous. With a
- * buffer size of 1, you get the familiar MVar structure. The channel may be
- * shared between many sending and receiving domains. *)
+    [Invalid_argument "Chan.make_bounded"] if the buffer size is less than 0.
+
+    With a buffer size of 0, the send operation becomes synchronous. With a
+    buffer size of 1, you get the familiar MVar structure. The channel may be
+    shared between many sending and receiving domains. *)
 
 val make_unbounded : unit -> 'a t
 (** Returns an unbounded channel *)
 
 val send : 'a t -> 'a -> unit
 (** [send c v] sends the values [v] over the channel [c]. If the channel buffer
- * is full then the sending domain blocks until space becomes available. *)
+    is full then the sending domain blocks until space becomes available. *)
 
 val send_poll : 'a t -> 'a -> bool
 (** [send_poll c v] attempts to send the value [v] over the channel [c]. If the
- * channel buffer is not full, the message is sent and returns [true]. Otherwise,
- * returns [false]. *)
+    channel buffer is not full, the message is sent and returns [true]. Otherwise,
+    returns [false]. *)
 
 val recv : 'a t -> 'a
 (** [recv c] returns a value [v] received over the channel. If the channel
- * buffer is empty then the domain blocks until a message is sent on the
- * channel. *)
+    buffer is empty then the domain blocks until a message is sent on the
+    channel. *)
 
 val recv_poll : 'a t -> 'a option
 (** [recv_poll c] attempts to receive a message on the channel [c]. If a
- * message [v] is available on the channel then [Some v] is returned.
- * Otherwise, returns [None]. *)
+    message [v] is available on the channel then [Some v] is returned.
+    Otherwise, returns [None]. *)

--- a/lib/fun_queue.mli
+++ b/lib/fun_queue.mli
@@ -12,5 +12,5 @@ val push : 'a t -> 'a -> 'a t
 
 val pop : 'a t -> ('a * 'a t) option
 (** [pop q] returns [None] if the queue is empty. If the queue is non-empty, it
- * returns [Some (v,q')] where [v] is the element popped from the head of [q]
- * and [q'] is the rest of the queue. *)
+    returns [Some (v,q')] where [v] is the element popped from the head of [q]
+    and [q'] is the rest of the queue. *)

--- a/lib/task.mli
+++ b/lib/task.mli
@@ -41,8 +41,7 @@ val run : pool -> 'a task -> 'a
 
 val async : pool -> 'a task -> 'a promise
 (** [async p t] runs the task [t] asynchronously in the pool [p]. The function
-    returns a promise [r] in which the result of the task [t] will be stored.
-  *)
+    returns a promise [r] in which the result of the task [t] will be stored. *)
 
 val await : pool -> 'a promise -> 'a
 (** [await p r] waits for the promise [r] to be resolved. During the resolution,


### PR DESCRIPTION
While looking at the documentation on ocaml.org ([see `Domainslib.Chan`](https://ocaml.org/p/domainslib/0.5.0/doc/Domainslib/Chan/index.html)), I noticed that it didn't look quite right with `*` sprinkled in the sentences.

This PR removes leading `*`s since they are not stripped by odoc or ocaml.org's doc presentation.