### PR TITLE
Fix a benign data-race in Chan reported by ocaml-tsan

### DIFF
--- a/lib/chan.ml
+++ b/lib/chan.ml
@@ -86,8 +86,8 @@ let rec send' {buffer_size; contents} v ~polling =
         let new_contents = Empty {receivers= receivers'} in
         if Atomic.compare_and_set contents old_contents new_contents
         then begin
-          r := Some v;
           Mutex.lock mc.mutex;
+          r := Some v;
           Mutex.unlock mc.mutex;
           Condition.broadcast mc.condition;
           true
@@ -192,8 +192,8 @@ let rec recv' {buffer_size; contents} ~polling =
           in
           if Atomic.compare_and_set contents old_contents new_contents
           then begin
-            c := Notified;
             Mutex.lock mc.mutex;
+            c := Notified;
             Mutex.unlock mc.mutex;
             Condition.broadcast mc.condition;
             Some m
@@ -206,8 +206,8 @@ let rec recv' {buffer_size; contents} ~polling =
           in
           if Atomic.compare_and_set contents old_contents new_contents
           then begin
-            sc := Notified;
             Mutex.lock mc.mutex;
+            sc := Notified;
             Mutex.unlock mc.mutex;
             Condition.broadcast mc.condition;
             Some m


### PR DESCRIPTION
`tsan` thinks that the previous code looked weird and I tend to agree (but I'm guessing it can't actually go bad?)

Now to confuse the reviewers and for context, the `ref` updates outside the mutex was introduced in https://github.com/ocaml-multicore/domainslib/pull/24 (https://github.com/ocaml-multicore/domainslib/pull/24/commits/e81e1f5d866196b1fe4c00f86d3315e7b9caa9a6), so there might be reasons for doing it that way? (cc @ctk21 in case you remember) (Should we rather switch the ref to an atomic?)