### PR TITLE
Add domain local await support

### DIFF
--- a/domainslib.opam
+++ b/domainslib.opam
@@ -11,6 +11,8 @@ depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "5.0"}
   "lockfree" {>= "0.2.0"}
+  "domain-local-await" {>= "0.1.0"}
+  "kcas" {>= "0.3.0" & with-test}
   "mirage-clock-unix" {with-test & >= "4.2.0"}
   "qcheck-core" {with-test & >= "0.20"}
   "qcheck-multicoretests-util" {with-test & >= "0.1"}

--- a/dune-project
+++ b/dune-project
@@ -15,6 +15,8 @@
  (depends
   (ocaml (>= "5.0"))
   (lockfree (>= "0.2.0"))
+  (domain-local-await (>= 0.1.0))
+  (kcas (and (>= 0.3.0) :with-test))
   (mirage-clock-unix (and :with-test (>= "4.2.0")))
   (qcheck-core (and :with-test (>= "0.20")))
   (qcheck-multicoretests-util (and :with-test (>= "0.1")))

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name domainslib)
  (public_name domainslib)
- (libraries lockfree))
+ (libraries lockfree domain-local-await))

--- a/test/dune
+++ b/test/dune
@@ -16,6 +16,12 @@
  (modes native))
 
 (test
+ (name kcas_integration)
+ (libraries domainslib kcas)
+ (modules kcas_integration)
+ (modes native))
+
+(test
  (name enumerate_par)
  (libraries domainslib)
  (modules enumerate_par)

--- a/test/kcas_integration.ml
+++ b/test/kcas_integration.ml
@@ -1,0 +1,29 @@
+open Kcas
+module T = Domainslib.Task
+
+let var = Loc.make None
+
+let () =
+  let n = 100 in
+  let pool_domain =
+    Domain.spawn @@ fun () ->
+    let pool =
+      T.setup_pool ~num_domains:(Domain.recommended_domain_count () - 2) ()
+    in
+    T.run pool (fun () ->
+        T.parallel_for ~start:1 ~finish:n
+          ~body:(fun i ->
+            ignore @@ Loc.update var
+            @@ function None -> Some i | _ -> Retry.later ())
+          pool);
+    T.teardown_pool pool;
+    Printf.printf "Done\n%!"
+  in
+  for _ = 1 to n do
+    match
+      Loc.update var @@ function None -> Retry.later () | Some _ -> None
+    with
+    | None -> failwith "impossible"
+    | Some i -> Printf.printf "Got %d\n%!" i
+  done;
+  Domain.join pool_domain


### PR DESCRIPTION
This PR adds [domain local await](https://github.com/ocaml-multicore/domain-local-await) support to Domainslib.  Domain local await allows blocking abstractions to work across different schedulers.