### PR TITLE
Adjust PBTs based on recommended_domain_count

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -36,7 +36,7 @@
  (libraries domainslib)
  (flags (:standard -runtime-variant d))
  (modules LU_decomposition_multicore)
- (enabled_if (or (= %{arch_sixtyfour} true) (<> %{architecture} arm)))
+ (enabled_if (or (= %{arch_sixtyfour} true) (<> %{architecture} arm))))
    ;; disabled temporarily on arm32 due to failure: ocaml/ocaml#12267
 
 

--- a/test/dune
+++ b/test/dune
@@ -108,12 +108,14 @@
  (name task_one_dep)
  (modules task_one_dep)
  (libraries qcheck-multicoretests-util qcheck-core qcheck-core.runner domainslib)
+ (enabled_if (= %{arch_sixtyfour} true)) ;; takes forever on 32-bit (bytecode)
  (action (run %{test} --verbose)))
 
 (test
  (name task_more_deps)
  (modules task_more_deps)
  (libraries qcheck-multicoretests-util qcheck-core qcheck-core.runner domainslib)
+ (enabled_if (= %{arch_sixtyfour} true)) ;; takes forever on 32-bit (bytecode)
  (action (run %{test} --verbose)))
 
 (test

--- a/test/dune
+++ b/test/dune
@@ -35,7 +35,9 @@
  (name LU_decomposition_multicore)
  (libraries domainslib)
  (flags (:standard -runtime-variant d))
- (modules LU_decomposition_multicore))
+ (modules LU_decomposition_multicore)
+ (enabled_if (or (= %{arch_sixtyfour} true) (<> %{architecture} arm)))
+   ;; disabled temporarily on arm32 due to failure: ocaml/ocaml#12267
 
 
 (test

--- a/test/dune
+++ b/test/dune
@@ -97,7 +97,9 @@
 (test
  (name backtrace)
  (libraries domainslib)
- (modules backtrace))
+ (modules backtrace)
+ (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power))))
+ ;; disabled temporarily on bytecode switches https://github.com/ocaml/dune/issues/7845
 
 (test
  (name off_by_one)

--- a/test/dune
+++ b/test/dune
@@ -98,7 +98,7 @@
  (name backtrace)
  (libraries domainslib)
  (modules backtrace)
- (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power))))
+ (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power) (<> %{architecture} s390x))))
  ;; disabled temporarily on bytecode switches https://github.com/ocaml/dune/issues/7845
 
 (test
@@ -112,14 +112,16 @@
  (name task_one_dep)
  (modules task_one_dep)
  (libraries qcheck-multicoretests-util qcheck-core qcheck-core.runner domainslib)
- (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power))) ;; takes forever on bytecode
+ (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power) (<> %{architecture} s390x)))
+ ;; takes forever on bytecode
  (action (run %{test} --verbose)))
 
 (test
  (name task_more_deps)
  (modules task_more_deps)
  (libraries qcheck-multicoretests-util qcheck-core qcheck-core.runner domainslib)
- (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power))) ;; takes forever on bytecode
+ (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power) (<> %{architecture} s390x)))
+ ;; takes forever on bytecode
  (action (run %{test} --verbose)))
 
 (test

--- a/test/dune
+++ b/test/dune
@@ -1,127 +1,106 @@
 (test
  (name test_chan)
  (libraries domainslib)
- (modules test_chan)
- (modes native))
+ (modules test_chan))
 
 (test
  (name fib)
- (modules fib)
- (modes native))
+ (modules fib))
 
 (test
  (name fib_par)
  (libraries domainslib)
- (modules fib_par)
- (modes native))
+ (modules fib_par))
 
 (test
  (name kcas_integration)
  (libraries domainslib kcas)
- (modules kcas_integration)
- (modes native))
+ (modules kcas_integration))
 
 (test
  (name enumerate_par)
  (libraries domainslib)
- (modules enumerate_par)
- (modes native))
+ (modules enumerate_par))
 
 (test
  (name game_of_life)
- (modules game_of_life)
- (modes native))
+ (modules game_of_life))
 
 (test
  (name game_of_life_multicore)
  (libraries domainslib)
- (modules game_of_life_multicore)
- (modes native))
+ (modules game_of_life_multicore))
 
 (test
  (name LU_decomposition_multicore)
  (libraries domainslib)
  (flags (:standard -runtime-variant d))
- (modules LU_decomposition_multicore)
- (modes native))
+ (modules LU_decomposition_multicore))
 
 
 (test
  (name spectralnorm2)
- (modules spectralnorm2)
- (modes native))
+ (modules spectralnorm2))
 
 (test
-  (name sum_par)
-  (libraries domainslib)
-	(modules sum_par)
-	(modes native))
+ (name sum_par)
+ (libraries domainslib)
+ (modules sum_par))
 
 (test
  (name task_throughput)
  (libraries domainslib mirage-clock-unix)
- (modules task_throughput)
- (modes native))
+ (modules task_throughput))
 
 (test
  (name spectralnorm2_multicore)
  (libraries domainslib)
- (modules spectralnorm2_multicore)
- (modes native))
+ (modules spectralnorm2_multicore))
 
 (test
  (name summed_area_table)
  (libraries domainslib)
- (modules summed_area_table)
- (modes native))
+ (modules summed_area_table))
 
 (test
  (name prefix_sum)
  (libraries domainslib unix)
- (modules prefix_sum)
- (modes native))
+ (modules prefix_sum))
 
 (test
  (name test_task)
  (libraries domainslib)
- (modules test_task)
- (modes native))
+ (modules test_task))
 
 (test
  (name test_parallel_find)
  (libraries domainslib)
- (modules test_parallel_find)
- (modes native))
+ (modules test_parallel_find))
 
 (test
  (name test_deadlock)
  (libraries domainslib)
- (modules test_deadlock)
- (modes native))
+ (modules test_deadlock))
 
 (test
  (name test_task_crash)
  (libraries domainslib)
- (modules test_task_crash)
- (modes native))
+ (modules test_task_crash))
 
 (test
  (name test_task_empty)
  (libraries domainslib)
- (modules test_task_empty)
- (modes native))
+ (modules test_task_empty))
 
 (test
  (name backtrace)
  (libraries domainslib)
- (modules backtrace)
- (modes native))
+ (modules backtrace))
 
 (test
  (name off_by_one)
  (libraries domainslib)
- (modules off_by_one)
- (modes native))
+ (modules off_by_one))
 
 ;; Custom property-based tests using QCheck
 

--- a/test/dune
+++ b/test/dune
@@ -108,14 +108,14 @@
  (name task_one_dep)
  (modules task_one_dep)
  (libraries qcheck-multicoretests-util qcheck-core qcheck-core.runner domainslib)
- (enabled_if (= %{arch_sixtyfour} true)) ;; takes forever on 32-bit (bytecode)
+ (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power))) ;; takes forever on bytecode
  (action (run %{test} --verbose)))
 
 (test
  (name task_more_deps)
  (modules task_more_deps)
  (libraries qcheck-multicoretests-util qcheck-core qcheck-core.runner domainslib)
- (enabled_if (= %{arch_sixtyfour} true)) ;; takes forever on 32-bit (bytecode)
+ (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power))) ;; takes forever on bytecode
  (action (run %{test} --verbose)))
 
 (test

--- a/test/off_by_one.ml
+++ b/test/off_by_one.ml
@@ -10,11 +10,18 @@ let print_array a =
 let r = Array.init 20 (fun i -> i + 1)
 
 let scan_task num_doms =
-  let pool = Task.setup_pool ~num_domains:num_doms () in
-  let a = Task.run pool (fun () -> Task.parallel_scan pool (+) (Array.make 20 1)) in
-  Task.teardown_pool pool;
-  Printf.printf "%i:  %s\n%!" num_doms (print_array a);
-  assert (a = r)
+  try
+    let pool = Task.setup_pool ~num_domains:num_doms () in
+    let a = Task.run pool (fun () -> Task.parallel_scan pool (+) (Array.make 20 1)) in
+    Task.teardown_pool pool;
+    Printf.printf "%i:  %s\n%!" num_doms (print_array a);
+    assert (a = r)
+  with Failure msg ->
+    begin
+      assert (msg = "failed to allocate domain");
+      Printf.printf "Failed to allocate %i domains, recommended_domain_count: %i\n%!"
+        num_doms (Domain.recommended_domain_count ());
+    end
 ;;
 for num_dom=0 to 21 do
   scan_task num_dom;

--- a/test/task_one_dep.ml
+++ b/test/task_one_dep.ml
@@ -140,8 +140,10 @@ let test_two_nested_pools ~domain_bound ~promise_bound =
      true)
 
 let () =
+  let domain_bound = max 1 (Domain.recommended_domain_count () / 2) in
+  let promise_bound = max 2 domain_bound in
   QCheck_base_runner.run_tests_main [
-    test_one_pool            ~domain_bound:8 ~promise_bound:10;
-    test_two_pools_sync_last ~domain_bound:2 ~promise_bound:2;
-    test_two_nested_pools    ~domain_bound:8 ~promise_bound:10;
+    test_one_pool            ~domain_bound ~promise_bound;
+    test_two_pools_sync_last ~domain_bound ~promise_bound;
+    test_two_nested_pools    ~domain_bound ~promise_bound;
   ]


### PR DESCRIPTION
I noticed the CI run of #110 had 32-bit `Failure("failed to allocate domain")` in test/task_one_dep.ml

I believe this is because the test does not take into account the available cores on the target machine.
This PR therefore adjusts the test to do so.

I hope this is sufficient to please the (32-bit) CI so that we can avoid disabling certain platforms like #111 proposes :crossed_fingers: 