### PR TITLE
Test condition tweaks

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -98,8 +98,14 @@
  (name backtrace)
  (libraries domainslib)
  (modules backtrace)
- (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power) (<> %{architecture} s390x))))
- ;; disabled temporarily on bytecode switches https://github.com/ocaml/dune/issues/7845
+ (modes byte native))
+ ;; byte_complete .exes don't include debug+trace info https://github.com/ocaml/dune/issues/7845
+ ;; so on a bytecode switch/platform we build a plain bytecode version w/trace info
+ ;; and rename it to .exe
+(rule
+ (target backtrace.exe)
+ (action (copy backtrace.bc backtrace.exe))
+ (enabled_if (= %{bin-available:ocamlopt} false)))
 
 (test
  (name off_by_one)

--- a/test/dune
+++ b/test/dune
@@ -98,6 +98,7 @@
  (name backtrace)
  (libraries domainslib)
  (modules backtrace)
+ (enabled_if (<> %{system} mingw64)) ;; triggers a known issue on mingw https://github.com/ocaml/ocaml/pull/12231
  (modes byte native))
  ;; byte_complete .exes don't include debug+trace info https://github.com/ocaml/dune/issues/7845
  ;; so on a bytecode switch/platform we build a plain bytecode version w/trace info
@@ -105,7 +106,7 @@
 (rule
  (target backtrace.exe)
  (action (copy backtrace.bc backtrace.exe))
- (enabled_if (= %{bin-available:ocamlopt} false)))
+ (enabled_if (and (= %{bin-available:ocamlopt} false) (<> %{system} mingw64))))
 
 (test
  (name off_by_one)

--- a/test/dune
+++ b/test/dune
@@ -118,16 +118,14 @@
  (name task_one_dep)
  (modules task_one_dep)
  (libraries qcheck-multicoretests-util qcheck-core qcheck-core.runner domainslib)
- (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power) (<> %{architecture} s390x)))
- ;; takes forever on bytecode
+ (enabled_if %{bin-available:ocamlopt}) ;; takes forever on bytecode
  (action (run %{test} --verbose)))
 
 (test
  (name task_more_deps)
  (modules task_more_deps)
  (libraries qcheck-multicoretests-util qcheck-core qcheck-core.runner domainslib)
- (enabled_if (and (= %{arch_sixtyfour} true) (<> %{architecture} power) (<> %{architecture} s390x)))
- ;; takes forever on bytecode
+ (enabled_if %{bin-available:ocamlopt}) ;; takes forever on bytecode
  (action (run %{test} --verbose)))
 
 (test


### PR DESCRIPTION
This PR tweaks the conditions for some of tests
- using a trick from https://github.com/ocaml/dune/issues/7845 to enable the `backtrace` test to also run on bytecode switches/platforms and
- simplifying the "native only" test condition

The latter has the benefit of requiring no future tweaking when 5.1 is released with a restored native-code backend for s390x (and later again for ppc64).
