### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ opam install domainslib
 If you are interested in hacking on the implementation, then `opam pin` this repository:
 
 ```bash
-$ opam switch create 5.0.0+trunk --repo=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+$ opam switch create 5.0.1+trunk --repo=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
 $ git clone https://github.com/ocaml-multicore/domainslib
 $ cd domainslib
 $ opam pin add domainslib file://`pwd`


### PR DESCRIPTION
I ran intho the following issue trying to hack on the implementation.

```sh
>> opam --version
2.1.5
>> opam switch create 5.0.0+trunk --repos alpha,default

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
Switch invariant: ["ocaml-variants" {= "5.0.0+trunk"}]
[ERROR] Could not determine which packages to install for this switch:
  * Missing dependency:
    - ocaml-variants > 5.3.1~
    no matching version
>> opam switch list-available --repositories alpha,beta,default
ocaml-base-compiler                    5.0.0                                  Official release 5.0.0
ocaml-variants                         5.0.0+options                          Official release of OCaml 5.0.0
ocaml-variants                         5.0.0+tsan                             OCaml 5.0.0, with ThreadSanitizer instrumentation
ocaml-variants                         5.0.1+trunk                            Latest 5.0 development
ocaml-base-compiler                    5.1.0~alpha1                           First alpha release of OCaml 5.1.0
>> opam switch create 5.0.1+trunk --repos alpha,default

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
Switch invariant: ["ocaml-variants" {= "5.0.1+trunk"}]

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
∗ installed base-bigarray.base
∗ installed base-threads.base
∗ installed base-unix.base
⬇ retrieved ocaml-variants.5.0.1+trunk  (https://github.com/ocaml/ocaml/archive/5.0.tar.gz)
∗ installed ocaml-variants.5.0.1+trunk
∗ installed ocaml-config.3
∗ installed ocaml.5.0.1
∗ installed base-domains.base
∗ installed base-nnp.base
Done.
# Run eval $(opam env --switch=5.0.1+trunk) to update the current shell environment`